### PR TITLE
Fix Chart Height in mobile view

### DIFF
--- a/src/components/OrganisationCard.js
+++ b/src/components/OrganisationCard.js
@@ -8,6 +8,7 @@ import TopTechTag from './TopTechTag';
 
 const OrganisationCard = (props) => {
   const { orgData } = props;
+  const isMobile = window.innerWidth <= 750;
   const graphData = {
     labels: [2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019],
     datasets: [
@@ -56,7 +57,10 @@ const OrganisationCard = (props) => {
             </div>
           </h3>
           <div className='graph'>
-            <Line data={graphData} />
+            <Line
+              data={graphData}
+              height={isMobile ? 300 : 250}
+            />
           </div>
           <br />
           <br />

--- a/src/components/OrganisationCard.js
+++ b/src/components/OrganisationCard.js
@@ -60,6 +60,18 @@ const OrganisationCard = (props) => {
             <Line
               data={graphData}
               height={isMobile ? 300 : 250}
+              options={{
+                maintainAspectRatio: false,
+                scales: {
+                  yAxes: [
+                    {
+                      ticks: {
+                        precision: 0,
+                      },
+                    },
+                  ],
+                },
+              }}
             />
           </div>
           <br />


### PR DESCRIPTION
### Description
- added custom height for mobile and desktop view
- fixed chart precision to avoid decimal places on Y-axis.

### Screens
![image](https://user-images.githubusercontent.com/26011845/95011219-bb06d380-064c-11eb-8434-9d297dc4e817.png)

![image](https://user-images.githubusercontent.com/26011845/95011191-901c7f80-064c-11eb-811a-0f8794d1d77c.png)

### Fixes
This closes #5 