### PR TITLE
fix: removes horizontal padding from tablet and mobile view

### DIFF
--- a/src/css/mainpagecss.css
+++ b/src/css/mainpagecss.css
@@ -6,6 +6,15 @@
   color: white;
   width: 100%;
 }
+
+@media screen and (max-width: 768px) {
+  #mainContainer {
+    margin: 0!important;
+    padding-left: 1.2em;
+    padding-right: 1.2em;
+  }
+}
+
 @media (max-width: 750px) {
   #searchBox {
     width: 65%;


### PR DESCRIPTION
Fixes: #20 

The extra margin was coming from semantic-ui's CSS code.

After removing the extra margin from mobile and tablet views the UI looks like this

![ui-with-fix](https://user-images.githubusercontent.com/8468992/135635999-28f332d4-7ee8-475c-8615-3ee3a8323829.png)

