### PR TITLE
Add 2021 data

### DIFF
--- a/src/components/OrganisationCard.js
+++ b/src/components/OrganisationCard.js
@@ -10,7 +10,7 @@ const OrganisationCard = (props) => {
   const { orgData } = props;
   const isMobile = window.innerWidth <= 750;
   const graphData = {
-    labels: [2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020],
+    labels: [2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021],
     datasets: [
       {
         label: 'No. of Projects',

--- a/src/data/finalData.json
+++ b/src/data/finalData.json
@@ -1,17029 +1,20208 @@
 [
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6309633414660096/",
-            "name": "52\u00b0 North GmbH",
-            "tech": [
-                  "java",
-                  "android",
-                  "javascript",
-                  "python",
-                  "react"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "web services",
-                  "floating car data",
-                  "ogc standards",
-                  "trajectory analytics"
-            ],
-            "year": [
-                  2020
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6689005560659968/",
-            "name": "AboutCode.org",
-            "tech": [
-                  "python",
-                  "c/c++",
-                  "rust",
-                  "javascript",
-                  "postgresql"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "dependencies",
-                  "license-scan",
-                  "application security",
-                  "software analysis",
-                  "machine learning"
-            ],
-            "year": [
-                  2020,
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  5
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6043464124334080/",
-            "name": "Academy Software Foundation (ASWF)",
-            "tech": [
-                  "c/c++",
-                  "python"
-            ],
-            "cat": "Graphics / Video / Audio / Virtual Reality",
-            "top": [
-                  "2d/3d graphics",
-                  "cloud computing",
-                  "file formats",
-                  "color management",
-                  "filmmaking"
-            ],
-            "year": [
-                  2020
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5947521500708864/",
-            "name": "Accord Project",
-            "tech": [
-                  "javascript",
-                  "react",
-                  "coq",
-                  "ocaml",
-                  "compiler"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "smart contracts",
-                  "legal",
-                  "blockchain",
-                  "compilers",
-                  "ai"
-            ],
-            "year": [
-                  2020
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5720999993016320/",
-            "name": "AerospaceResearch.net",
-            "tech": [
-                  "python",
-                  "vhdl",
-                  "raspberry pi",
-                  "sqlite",
-                  "c++"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "cubesats",
-                  "space applications",
-                  "software defined radio",
-                  "distributed computing",
-                  "simulations"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  6,
-                  6,
-                  7,
-                  5
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6438212253253632/",
-            "name": "afl++",
-            "tech": [
-                  "fuzzing",
-                  "c/c++",
-                  "qemu",
-                  "llvm",
-                  "sanitizers"
-            ],
-            "cat": "Security",
-            "top": [
-                  "bug finding",
-                  "software testing",
-                  "fuzzing"
-            ],
-            "year": [
-                  2020
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5480514170912768/",
-            "name": "Amahi",
-            "tech": [
-                  "ruby on rails",
-                  "javascript",
-                  "android",
-                  "golang",
-                  "swift"
-            ],
-            "cat": "Operating Systems",
-            "top": [
-                  "operating systems",
-                  " networking",
-                  " web servers",
-                  "streaming",
-                  "mobile-apps"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2014
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  0,
-                  0,
-                  3,
-                  5,
-                  7,
-                  3
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5158050039595008/",
-            "name": "Android Graphics Tools Team",
-            "tech": [
-                  "vulkan",
-                  "opengl",
-                  "c/c++",
-                  "java",
-                  "python 3"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "developer tools",
-                  "2d/3d graphics",
-                  "debugging",
-                  "profiling",
-                  "bug finding"
-            ],
-            "year": [
-                  2020,
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  3
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5270382996619264/",
-            "name": "AnitaB.org Open Source",
-            "tech": [
-                  "ios",
-                  "android",
-                  "python",
-                  "javascript"
-            ],
-            "cat": "Other",
-            "top": [
-                  "mobile",
-                  " web",
-                  "mobile programming",
-                  "web programming"
-            ],
-            "year": [
-                  2020
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  4
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5037209255673856/",
-            "name": "AOSSIE",
-            "tech": [
-                  "javascript",
-                  "swift",
-                  "kotlin",
-                  "python"
-            ],
-            "cat": "End User Applications",
-            "top": [
-                  "electronic voting",
-                  "natural language processing",
-                  "machine learning",
-                  "environment",
-                  "social science"
-            ],
-            "year": [
-                  2020
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  9
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6269334810263552/",
-            "name": "Apertium",
-            "tech": [
-                  "c++",
-                  "bash",
-                  "python",
-                  "xml"
-            ],
-            "cat": "Other",
-            "top": [
-                  "machine translation",
-                  "natural language processing",
-                  "less-resourced languages"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2014,
-                  2013,
-                  2012,
-                  2011,
-                  2010
-            ],
-            "project": [
-                  0,
-                  8,
-                  9,
-                  10,
-                  10,
-                  15,
-                  0,
-                  0,
-                  10,
-                  11,
-                  10,
-                  7
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6145737898852352/",
-            "name": "apertus\u00b0 Association",
-            "tech": [
-                  "fpga",
-                  "vhdl",
-                  "c/c++",
-                  "linux",
-                  "embedded"
-            ],
-            "cat": "Graphics / Video / Audio / Virtual Reality",
-            "top": [
-                  "camera",
-                  "vision",
-                  "computational photography",
-                  "image processing",
-                  "digital imaging"
-            ],
-            "year": [
-                  2020,
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  4,
-                  4
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5459614121852928/",
-            "name": "appleseed",
-            "tech": [
-                  "c++11",
-                  "python",
-                  "opengl"
-            ],
-            "cat": "Graphics / Video / Audio / Virtual Reality",
-            "top": [
-                  "computer graphics",
-                  "image synthesis",
-                  "rendering",
-                  "animation",
-                  "simulation"
-            ],
-            "year": [
-                  2020,
-                  2014
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6264664972853248/",
-            "name": "Arduino",
-            "tech": [
-                  "arduino",
-                  "golang",
-                  "c/c++"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "electronics",
-                  " robotics",
-                  "interactivity"
-            ],
-            "year": [
-                  2020
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5108253115023360/",
-            "name": "ArduPilot",
-            "tech": [
-                  "drones",
-                  "python",
-                  "robotics",
-                  "linux",
-                  "c/c++"
-            ],
-            "cat": "Other",
-            "top": [
-                  "vision",
-                  "robotics",
-                  "embedded systems",
-                  "real-time os",
-                  "drones"
-            ],
-            "year": [
-                  2020,
-                  2018,
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  5,
-                  0,
-                  5
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5073969981423616/",
-            "name": "BeagleBoard.org",
-            "tech": [
-                  "linux",
-                  "tensorflow",
-                  "python",
-                  "javascript",
-                  "opencv"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "robotics",
-                  "iot",
-                  "teaching",
-                  "real-time",
-                  "embedded"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2016,
-                  2015,
-                  2014,
-                  2013,
-                  2010
-            ],
-            "project": [
-                  0,
-                  6,
-                  0,
-                  0,
-                  6,
-                  6,
-                  7,
-                  6,
-                  0,
-                  0,
-                  3,
-                  4
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6683736474648576/",
-            "name": "BioGears",
-            "tech": [
-                  "c++11",
-                  "c/c++",
-                  "python",
-                  "cmake"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "physiology",
-                  "pharmacological modeling",
-                  "computational biology",
-                  "mathematical software"
-            ],
-            "year": [
-                  2020
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4852657564418048/",
-            "name": "Blender Foundation",
-            "tech": [
-                  "c",
-                  "c++",
-                  "python",
-                  "opengl",
-                  "vulkan"
-            ],
-            "cat": "Graphics / Video / Audio / Virtual Reality",
-            "top": [
-                  "3d",
-                  "graphics",
-                  "virtual reality",
-                  "animation",
-                  "artist tools"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2016,
-                  2014,
-                  2013,
-                  2012,
-                  2011,
-                  2010,
-                  2009
-            ],
-            "project": [
-                  6,
-                  10,
-                  15,
-                  13,
-                  12,
-                  7,
-                  0,
-                  8,
-                  5,
-                  5,
-                  7,
-                  9
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6585514028695552/",
-            "name": "Boost C++",
-            "tech": [
-                  "c++17",
-                  "c++11",
-                  "c++"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "programming libraries",
-                  "c++",
-                  "peer-reviewed libraries",
-                  "c++ standard"
-            ],
-            "year": [
-                  2020,
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  11,
-                  9
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6396282903461888/",
-            "name": "BRL-CAD",
-            "tech": [
-                  "opencl",
-                  "c/c++",
-                  "python",
-                  "tcl/tk",
-                  "opengl"
-            ],
-            "cat": "Graphics / Video / Audio / Virtual Reality",
-            "top": [
-                  "data visualization",
-                  "3d cad geometry",
-                  "ray tracing",
-                  "solid modeling",
-                  "real-time computer graphics"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2016,
-                  2015,
-                  2014,
-                  2013,
-                  2012,
-                  2011,
-                  2009
-            ],
-            "project": [
-                  3,
-                  0,
-                  2,
-                  7,
-                  7,
-                  10,
-                  9,
-                  9,
-                  8,
-                  7,
-                  8,
-                  8
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5978557471260672/",
-            "name": "caMicroscope",
-            "tech": [
-                  "javascript",
-                  "python",
-                  "java",
-                  "medical imaging",
-                  "tensorflow"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "science and medicine",
-                  " data integration",
-                  " distributed systems",
-                  " cloud",
-                  " precision medicine"
-            ],
-            "year": [
-                  2020
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5106421244362752/",
-            "name": "Canadian Centre for Computational Genomics",
-            "tech": [
-                  "python",
-                  "r-project",
-                  "javascript",
-                  "react",
-                  "nodejs"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "bioinformatics",
-                  "data science",
-                  "visualization",
-                  "statistics",
-                  "web development"
-            ],
-            "year": [
-                  2020,
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  0,
-                  5
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6587176113930240/",
-            "name": "Casbin",
-            "tech": [
-                  "go",
-                  "javascript",
-                  "react",
-                  "rust",
-                  "python"
-            ],
-            "cat": "Security",
-            "top": [
-                  "security",
-                  "front-end",
-                  "web",
-                  "cloud",
-                  "authorization"
-            ],
-            "year": [
-                  2020
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5707287336845312/",
-            "name": "Catrobat",
-            "tech": [
-                  "java",
-                  "android",
-                  "swift",
-                  "ios",
-                  "php"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "visual programming",
-                  "app development",
-                  "gaming",
-                  "creativity tools",
-                  "education"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  7,
-                  5,
-                  5,
-                  9,
-                  12
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5987859833552896/",
-            "name": "CCExtractor Development",
-            "tech": [
-                  "c",
-                  "python",
-                  "ml",
-                  "flutter",
-                  "rust"
-            ],
-            "cat": "Graphics / Video / Audio / Virtual Reality",
-            "top": [
-                  "vision",
-                  "ai",
-                  "media",
-                  "linux",
-                  "bittorrent"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  6,
-                  6,
-                  6,
-                  10,
-                  8
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6273779027673088/",
-            "name": "Ceph Foundation",
-            "tech": [
-                  "c/c++",
-                  "jenkins",
-                  "python",
-                  "javascript",
-                  "shell script"
-            ],
-            "cat": "Other",
-            "top": [
-                  " distributed systems",
-                  "software defined storage"
-            ],
-            "year": [
-                  2020
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  4
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5668658770083840/",
-            "name": "CERN-HSF",
-            "tech": [
-                  "c/c++",
-                  "python",
-                  "data analysis",
-                  "machine learning",
-                  "concurrency"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "big data",
-                  "machine learning",
-                  "performance optimization",
-                  "algorithmics",
-                  "particle physics"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  20,
-                  26,
-                  29,
-                  34
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6008526545092608/",
-            "name": "CGAL Project",
-            "tech": [
-                  "c++",
-                  "git",
-                  "qt"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "computational geometry",
-                  "geometry processing",
-                  "mesh processing",
-                  "triangulation",
-                  "arrangement"
-            ],
-            "year": [
-                  2020,
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  7,
-                  0,
-                  7
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6232321151205376/",
-            "name": "CHAOSS",
-            "tech": [
-                  "python",
-                  "javascript",
-                  "kibana",
-                  "elasticsearch",
-                  "mysql"
-            ],
-            "cat": "Other",
-            "top": [
-                  "community health",
-                  "analytics"
-            ],
-            "year": [
-                  2020,
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  4,
-                  9
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6722154118250496/",
-            "name": "Chapel",
-            "tech": [
-                  "chapel",
-                  "high performance computing",
-                  "c",
-                  "c++",
-                  "python"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "programming languages",
-                  "compilers",
-                  "high performance computing",
-                  "distributed computing",
-                  "parallel computing"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2017,
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  3,
-                  0,
-                  4,
-                  4
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5983189996142592/",
-            "name": "Checker Framework",
-            "tech": [
-                  "java"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "programmer productivity",
-                  "software engineering",
-                  "verification",
-                  "bug finding",
-                  "type systems"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  5,
-                  3,
-                  5,
-                  2
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4788704964509696/",
-            "name": "Checkstyle",
-            "tech": [
-                  "java",
-                  "antlr",
-                  "xpath"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "static code analysis\u200e",
-                  "code review tool",
-                  "coding standards",
-                  "coding conventions"
-            ],
-            "year": [
-                  2020,
-                  2017,
-                  2014
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  0,
-                  0,
-                  5,
-                  0,
-                  0,
-                  3
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5373782455222272/",
-            "name": "CircuitVerse.org",
-            "tech": [
-                  "rails",
-                  "javascript",
-                  "bootstrap",
-                  "html5",
-                  "canvas"
-            ],
-            "cat": "Web",
-            "top": [
-                  "web",
-                  "simulations",
-                  "pedagogy",
-                  "education",
-                  "digital logic design"
-            ],
-            "year": [
-                  2020,
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  4
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4923749205278720/",
-            "name": "CiviCRM",
-            "tech": [
-                  "php",
-                  "javascript",
-                  "angularjs",
-                  "mysql"
-            ],
-            "cat": "Data and Databases",
-            "top": [
-                  "crm",
-                  "nonprofits"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2016,
-                  2015,
-                  2014
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  5,
-                  8,
-                  8,
-                  0,
-                  0,
-                  2,
-                  4
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5861737481371648/",
-            "name": "Cloud Native Computing Foundation (CNCF)",
-            "tech": [
-                  "kubernetes",
-                  "golang",
-                  "cloud",
-                  "rust",
-                  "service mesh"
-            ],
-            "cat": "Cloud",
-            "top": [
-                  "cloud",
-                  " web",
-                  "devops",
-                  "kubernetes",
-                  "service mesh"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  6,
-                  7,
-                  15,
-                  17
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6719687229964288/",
-            "name": "CloudCV",
-            "tech": [
-                  "python",
-                  "django",
-                  "aws",
-                  "docker",
-                  "docker"
-            ],
-            "cat": "Cloud",
-            "top": [
-                  "machine learning",
-                  "artificial intelligence",
-                  "deep learning",
-                  "computer vision"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2016,
-                  2015
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  2,
-                  4,
-                  5,
-                  4,
-                  3
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6695549513760768/",
-            "name": "Continuous Delivery Foundation",
-            "tech": [
-                  "tekton",
-                  "spinnaker",
-                  "ci/cd",
-                  "screwdriver"
-            ],
-            "cat": "Cloud",
-            "top": [
-                  "continuous delivery",
-                  "continuous integration",
-                  "cloud",
-                  "devops"
-            ],
-            "year": [
-                  2020
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5721709165936640/",
-            "name": "coreboot",
-            "tech": [
-                  "c",
-                  "assembly",
-                  "x86",
-                  "arm"
-            ],
-            "cat": "Operating Systems",
-            "top": [
-                  "firmware",
-                  "boot loader",
-                  "drivers",
-                  "hardware"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2016,
-                  2015,
-                  2014,
-                  2013,
-                  2011,
-                  2010,
-                  2009
-            ],
-            "project": [
-                  3,
-                  5,
-                  4,
-                  0,
-                  4,
-                  3,
-                  2,
-                  3,
-                  0,
-                  0,
-                  3,
-                  2
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5450793232105472/",
-            "name": "Creative Commons",
-            "tech": [
-                  "javascript",
-                  "vue.js",
-                  "python",
-                  "django",
-                  "wordpress"
-            ],
-            "cat": "Web",
-            "top": [
-                  "copyleft",
-                  "web",
-                  "creative commons",
-                  "legal",
-                  "nonprofits"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2013,
-                  2012,
-                  2010,
-                  2009
-            ],
-            "project": [
-                  2,
-                  3,
-                  0,
-                  1,
-                  2,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  5,
-                  5
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5765173698101248/",
-            "name": "CRIU",
-            "tech": [
-                  "linux",
-                  "c",
-                  "assembly"
-            ],
-            "cat": "Operating Systems",
-            "top": [
-                  " cloud",
-                  "live migration",
-                  "snapshots"
-            ],
-            "year": [
-                  2020
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5649030769541120/",
-            "name": "Cuneiform Digital Library Initiative (CDLI)",
-            "tech": [
-                  "python 3",
-                  "php",
-                  "mysql",
-                  "html",
-                  "css"
-            ],
-            "cat": "Data and Databases",
-            "top": [
-                  "computational linguistics",
-                  "web portal",
-                  "data processing",
-                  "data visualization",
-                  "digitization"
-            ],
-            "year": [
-                  2020,
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  5,
-                  9
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5806784012353536/",
-            "name": "Dart",
-            "tech": [
-                  "dart",
-                  "flutter",
-                  "programming-language"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "mobile-apps"
-            ],
-            "year": [
-                  2020
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  5
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4792495004712960/",
-            "name": "DBpedia",
-            "tech": [
-                  "python",
-                  "scala",
-                  "java",
-                  "javascript",
-                  "rdf"
-            ],
-            "cat": "Data and Databases",
-            "top": [
-                  "knowledge graph",
-                  "natural language processing",
-                  "semantic web",
-                  "data science",
-                  "linked data"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  7,
-                  3,
-                  6,
-                  7
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6279124282245120/",
-            "name": "Debian",
-            "tech": [
-                  "git",
-                  "python",
-                  "javascript",
-                  "c/c++",
-                  "irc"
-            ],
-            "cat": "Operating Systems",
-            "top": [
-                  "operating systems",
-                  " kernel",
-                  "package managers",
-                  "packaging"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2009
-            ],
-            "project": [
-                  7,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  5,
-                  8
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6465676589400064/",
-            "name": "Digital Impact Alliance (DIAL) at UN Foundation",
-            "tech": [
-                  "c++",
-                  "javascript",
-                  "android",
-                  "php",
-                  "python"
-            ],
-            "cat": "Other",
-            "top": [
-                  "nonprofit",
-                  "humanrights",
-                  "humanitarian",
-                  "international",
-                  "global"
-            ],
-            "year": [
-                  2020
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  14
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5420240042721280/",
-            "name": "Django Software Foundation",
-            "tech": [
-                  "python",
-                  "django"
-            ],
-            "cat": "Web",
-            "top": [
-                  "web development"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2016,
-                  2014,
-                  2013,
-                  2012,
-                  2011,
-                  2010,
-                  2009
-            ],
-            "project": [
-                  6,
-                  2,
-                  3,
-                  1,
-                  3,
-                  2,
-                  0,
-                  1,
-                  0,
-                  0,
-                  2,
-                  2
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5836893377265664/",
-            "name": "Drupal",
-            "tech": [
-                  "php",
-                  "symfony",
-                  "sql",
-                  "javascript",
-                  "drupal 8"
-            ],
-            "cat": "Web",
-            "top": [
-                  "web development",
-                  "cms",
-                  "apps",
-                  "mobile-apps",
-                  "object oriented programming"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2016,
-                  2015,
-                  2014,
-                  2012,
-                  2011,
-                  2010,
-                  2009
-            ],
-            "project": [
-                  18,
-                  18,
-                  15,
-                  13,
-                  0,
-                  12,
-                  9,
-                  9,
-                  6,
-                  1,
-                  2,
-                  1
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4711920076062720/",
-            "name": "Eclipse Foundation",
-            "tech": [
-                  "eclipsejavaide",
-                  "jakartaee",
-                  "java",
-                  "che",
-                  "deep learning"
-            ],
-            "cat": "Other",
-            "top": [
-                  "cloud native java",
-                  "automotive",
-                  "tools",
-                  " robotics",
-                  "iot & edge"
-            ],
-            "year": [
-                  2020,
-                  2016,
-                  2009
-            ],
-            "project": [
-                  19,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  11,
-                  0,
-                  0,
-                  0,
-                  7
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4573440532545536/",
-            "name": "Elastic",
-            "tech": [
-                  "java",
-                  "react",
-                  "node.js",
-                  "golang"
-            ],
-            "cat": "Data and Databases",
-            "top": [
-                  "databases",
-                  "search",
-                  "security",
-                  "observability"
-            ],
-            "year": [
-                  2020,
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0,
-                  2
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4824946267652096/",
-            "name": "Embox",
-            "tech": [
-                  "c",
-                  "gcc",
-                  "assembly"
-            ],
-            "cat": "Operating Systems",
-            "top": [
-                  " embedded systems",
-                  "rtos"
-            ],
-            "year": [
-                  2020
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4857921046839296/",
-            "name": "Erlang Ecosystem Foundation",
-            "tech": [
-                  "erlang",
-                  "elixir",
-                  "lfe",
-                  "beam"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "language",
-                  "soft real-time",
-                  " distributed systems",
-                  "messaging",
-                  "instant messaging"
-            ],
-            "year": [
-                  2020
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6477554824773632/",
-            "name": "Fedora Project",
-            "tech": [
-                  "python 3",
-                  "rest",
-                  "linux",
-                  "web development",
-                  "linux distribution"
-            ],
-            "cat": "Operating Systems",
-            "top": [
-                  "containers",
-                  "linux",
-                  "distribution",
-                  "mobile",
-                  "web development"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  6,
-                  5,
-                  5,
-                  5,
-                  4
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4857919167791104/",
-            "name": "FFmpeg",
-            "tech": [
-                  "c",
-                  "asm",
-                  "git"
-            ],
-            "cat": "Graphics / Video / Audio / Virtual Reality",
-            "top": [
-                  "audio",
-                  "video",
-                  "subtitles",
-                  "multimedia"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2016,
-                  2015,
-                  2010,
-                  2009
-            ],
-            "project": [
-                  6,
-                  7,
-                  0,
-                  0,
-                  0,
-                  0,
-                  7,
-                  7,
-                  6,
-                  5,
-                  6,
-                  5
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6163301563629568/",
-            "name": "FOSSology",
-            "tech": [
-                  "php",
-                  "javascript",
-                  "c/c++",
-                  "twig",
-                  "python"
-            ],
-            "cat": "End User Applications",
-            "top": [
-                  "licensing",
-                  "compliance",
-                  "spdx",
-                  "oss licencing",
-                  "license-scan"
-            ],
-            "year": [
-                  2020,
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  0,
-                  3
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5699340439388160/",
-            "name": "FrameNet Brasil (UFJF)",
-            "tech": [
-                  "php",
-                  "mysql",
-                  "javascript",
-                  "python"
-            ],
-            "cat": "Data and Databases",
-            "top": [
-                  "natural language processing",
-                  "natural language understanding",
-                  "multimodality",
-                  " video processing",
-                  "multilinguality"
-            ],
-            "year": [
-                  2020
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6376070820921344/",
-            "name": "Free and Open Source Silicon Foundation",
-            "tech": [
-                  "verilog",
-                  "risc-v",
-                  "python",
-                  "c++"
-            ],
-            "cat": "Other",
-            "top": [
-                  "silicon",
-                  "eda",
-                  "fpga"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  4,
-                  6,
-                  7,
-                  4
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5650233226166272/",
-            "name": "FreeBSD Project",
-            "tech": [
-                  "c/c++",
-                  "llvm",
-                  "shell script",
-                  "assembly",
-                  "make"
-            ],
-            "cat": "Operating Systems",
-            "top": [
-                  "operating systems",
-                  "virtualization",
-                  "kernel",
-                  "cloud",
-                  "embedded systems"
-            ],
-            "year": [
-                  2020
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  6
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5205992846917632/",
-            "name": "FreeType",
-            "tech": [
-                  "c",
-                  "gnu make",
-                  "gnu autotools",
-                  "python",
-                  "fonts"
-            ],
-            "cat": "Graphics / Video / Audio / Virtual Reality",
-            "top": [
-                  "graphics",
-                  "library",
-                  "rendering",
-                  "fonts",
-                  "opentype"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  3,
-                  3
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5039063742021632/",
-            "name": "FRRouting",
-            "tech": [
-                  "c",
-                  "linux",
-                  "linux kernel",
-                  "networking",
-                  "lua"
-            ],
-            "cat": "Other",
-            "top": [
-                  " networking",
-                  "software defined networking",
-                  "linux",
-                  "performance",
-                  "systems programming"
-            ],
-            "year": [
-                  2020
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5791816890187776/",
-            "name": "GDevelop",
-            "tech": [
-                  "javascript",
-                  "c/c++",
-                  "web development",
-                  "game development",
-                  "react"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "gaming",
-                  "graphics",
-                  "web applications",
-                  " web",
-                  "compilers"
-            ],
-            "year": [
-                  2020
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4837823317803008/",
-            "name": "Gentoo Foundation",
-            "tech": [
-                  "shell",
-                  "bash",
-                  "c/c++",
-                  "python",
-                  "linux"
-            ],
-            "cat": "Operating Systems",
-            "top": [
-                  "operating systems",
-                  "package management",
-                  "embedded",
-                  "init",
-                  "security"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2016,
-                  2014,
-                  2013,
-                  2012,
-                  2011,
-                  2010
-            ],
-            "project": [
-                  0,
-                  16,
-                  14,
-                  8,
-                  6,
-                  3,
-                  0,
-                  5,
-                  3,
-                  2,
-                  2,
-                  4
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4606415412396032/",
-            "name": "GeomScale",
-            "tech": [
-                  "c++",
-                  "r",
-                  "python"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "mathematical software",
-                  "statistics",
-                  "biology",
-                  "optimization",
-                  "finance"
-            ],
-            "year": [
-                  2020
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5445576591671296/",
-            "name": "Git",
-            "tech": [
-                  "c",
-                  "shell script",
-                  "git"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "version control",
-                  "dvcs"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2016,
-                  2015,
-                  2014,
-                  2012,
-                  2011,
-                  2010
-            ],
-            "project": [
-                  0,
-                  3,
-                  5,
-                  3,
-                  0,
-                  2,
-                  2,
-                  1,
-                  1,
-                  3,
-                  2,
-                  3
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5086080816119808/",
-            "name": "Global Alliance for Genomics and Health",
-            "tech": [
-                  "java",
-                  "python",
-                  "node.js",
-                  "mongodb",
-                  "spring"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "genomics",
-                  "genetics",
-                  "bioinformatics",
-                  "web",
-                  "standards"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  4,
-                  5,
-                  4
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4988908019908608/",
-            "name": "GNOME",
-            "tech": [
-                  "c",
-                  "rust",
-                  "gtk",
-                  "vala",
-                  "python"
-            ],
-            "cat": "End User Applications",
-            "top": [
-                  "desktop",
-                  "games",
-                  "applications",
-                  "productivity"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2016,
-                  2015,
-                  2014,
-                  2013,
-                  2012,
-                  2010,
-                  2009
-            ],
-            "project": [
-                  24,
-                  20,
-                  0,
-                  28,
-                  29,
-                  35,
-                  22,
-                  18,
-                  19,
-                  13,
-                  8,
-                  14
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5600351610208256/",
-            "name": "GNSS-SDR",
-            "tech": [
-                  "c++",
-                  "gnss"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "gnss",
-                  "signal processing",
-                  "navigation",
-                  "software defined radio"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2015,
-                  2014,
-                  2013
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  4,
-                  6,
-                  0,
-                  5,
-                  5,
-                  3,
-                  2
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4862862406713344/",
-            "name": "GNU Compiler Collection (GCC)",
-            "tech": [
-                  "c/c++",
-                  "gnu autotools",
-                  "gnu make"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "compilers",
-                  "toolchain",
-                  " developer tools",
-                  "openmp"
-            ],
-            "year": [
-                  2020,
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  0,
-                  2
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4670095013445632/",
-            "name": "GNU Octave",
-            "tech": [
-                  "c++",
-                  "hg"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "mathematics",
-                  "numerical computation",
-                  "numerical methods",
-                  "matlab",
-                  "scientific computing"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2016,
-                  2014
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  0,
-                  5,
-                  4,
-                  3,
-                  0,
-                  1
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6206096819093504/",
-            "name": "GNU Radio",
-            "tech": [
-                  "python",
-                  "c++",
-                  "qt"
-            ],
-            "cat": "Other",
-            "top": [
-                  "software defined radio",
-                  "signal processing",
-                  "communication"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2016,
-                  2014,
-                  2013
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  5,
-                  4,
-                  0,
-                  2,
-                  2,
-                  2,
-                  2,
-                  1
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4877284235804672/",
-            "name": "Godot Engine",
-            "tech": [
-                  "c/c++",
-                  "opengl",
-                  "vulkan"
-            ],
-            "cat": "Graphics / Video / Audio / Virtual Reality",
-            "top": [
-                  "graphics",
-                  "game development",
-                  "cross-platform"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  5,
-                  8,
-                  6
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6028158437949440/",
-            "name": "GPAC",
-            "tech": [
-                  "c",
-                  "javascript",
-                  "opengl"
-            ],
-            "cat": "Graphics / Video / Audio / Virtual Reality",
-            "top": [
-                  "multimedia",
-                  "streaming",
-                  "packaging",
-                  "interactivity",
-                  "rendering"
-            ],
-            "year": [
-                  2020,
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6354766843609088/",
-            "name": "GraphQL Foundation",
-            "tech": [
-                  "graphql",
-                  "javascript",
-                  "react",
-                  "node.js"
-            ],
-            "cat": "Data and Databases",
-            "top": [
-                  "data and databases",
-                  "api",
-                  "graphql"
-            ],
-            "year": [
-                  2020
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5963723224645632/",
-            "name": "Haiku",
-            "tech": [
-                  "c++",
-                  "posix",
-                  "unix",
-                  "webkit"
-            ],
-            "cat": "Operating Systems",
-            "top": [
-                  "filesystem",
-                  "network",
-                  "virtualization",
-                  "kernel",
-                  "drivers"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2014,
-                  2012,
-                  2011,
-                  2010,
-                  2009
-            ],
-            "project": [
-                  5,
-                  5,
-                  4,
-                  5,
-                  0,
-                  2,
-                  0,
-                  0,
-                  5,
-                  2,
-                  1,
-                  4
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4947391960055808/",
-            "name": "Haskell.org",
-            "tech": [
-                  "haskell",
-                  "ghc",
-                  "cabal",
-                  "codeworld",
-                  "servant"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "haskell",
-                  "functional programming",
-                  " education",
-                  "build tools",
-                  "compilers"
-            ],
-            "year": [
-                  2020,
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  15,
-                  0,
-                  12
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6487112334966784/",
-            "name": "Hazelcast",
-            "tech": [
-                  "java",
-                  "distributed systems"
-            ],
-            "cat": "Data and Databases",
-            "top": [
-                  "in memory data grid",
-                  "data streaming",
-                  "stream processing"
-            ],
-            "year": [
-                  2020
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6369733965774848/",
-            "name": "Homebrew",
-            "tech": [
-                  "ruby",
-                  "bash"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "package managers",
-                  "package management",
-                  "macos",
-                  "linux"
-            ],
-            "year": [
-                  2020,
-                  2018,
-                  2017,
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  4,
-                  2,
-                  1,
-                  0,
-                  3
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4811360279461888/",
-            "name": "Hydra Ecosystem",
-            "tech": [
-                  "python",
-                  "rest",
-                  "apis",
-                  "hydra"
-            ],
-            "cat": "Web",
-            "top": [
-                  "web development",
-                  "http",
-                  "rest apis",
-                  "knowledge graph"
-            ],
-            "year": [
-                  2020,
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  2
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6550809786974208/",
-            "name": "INCF",
-            "tech": [
-                  "python",
-                  "c/c++",
-                  "java",
-                  "tensorflow",
-                  "javascript"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "neuroscience",
-                  "brain modelling",
-                  "neuroimage processing",
-                  "data visualization",
-                  " big data"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  13,
-                  16,
-                  17,
-                  21
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5992304050962432/",
-            "name": "Inclusive Design Institute",
-            "tech": [
-                  "javascript",
-                  "html",
-                  "css",
-                  "node.js"
-            ],
-            "cat": "End User Applications",
-            "top": [
-                  "accessibility",
-                  "inclusion",
-                  "web applications",
-                  "web development",
-                  "web"
-            ],
-            "year": [
-                  2020,
-                  2018,
-                  2016,
-                  2014,
-                  2013,
-                  2012,
-                  2010
-            ],
-            "project": [
-                  0,
-                  5,
-                  0,
-                  11,
-                  10,
-                  6,
-                  0,
-                  4,
-                  0,
-                  5,
-                  0,
-                  2
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4527035860385792/",
-            "name": "Inkscape",
-            "tech": [
-                  "c++",
-                  "svg",
-                  "gtk",
-                  "python"
-            ],
-            "cat": "Graphics / Video / Audio / Virtual Reality",
-            "top": [
-                  "graphics",
-                  "web",
-                  "geometry"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2016,
-                  2014,
-                  2013,
-                  2012,
-                  2011,
-                  2010,
-                  2009
-            ],
-            "project": [
-                  4,
-                  2,
-                  3,
-                  3,
-                  5,
-                  2,
-                  0,
-                  2,
-                  2,
-                  0,
-                  1,
-                  3
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5820969215590400/",
-            "name": "Intel Media And Audio For Linux",
-            "tech": [
-                  "ffmpeg",
-                  "gstreamer",
-                  "sound open firmware",
-                  "libxcam",
-                  "vaapi"
-            ],
-            "cat": "Graphics / Video / Audio / Virtual Reality",
-            "top": [
-                  "360 stereo video",
-                  "opensource audio firmware",
-                  "ffmpeg neuronetwork"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  2,
-                  2
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5652935767228416/",
-            "name": "Internet Archive",
-            "tech": [
-                  "javascript",
-                  "python"
-            ],
-            "cat": "Web",
-            "top": [
-                  "web archving",
-                  "library",
-                  "books"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  5,
-                  2,
-                  3
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6073291866898432/",
-            "name": "JBoss Community",
-            "tech": [
-                  "java",
-                  "golang",
-                  "react"
-            ],
-            "cat": "Web",
-            "top": [
-                  "programming languages and development tools",
-                  "cloud",
-                  "database",
-                  "kubernetes",
-                  "aerogear"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2016,
-                  2015,
-                  2014,
-                  2013,
-                  2012
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  8,
-                  6,
-                  5,
-                  10,
-                  9,
-                  3,
-                  3,
-                  8,
-                  10
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6129466817904640/",
-            "name": "JdeRobot - Universidad Rey Juan Carlos",
-            "tech": [
-                  "ros",
-                  "gazebo",
-                  "python",
-                  "c/c++",
-                  "opencv"
-            ],
-            "cat": "Other",
-            "top": [
-                  "robotics",
-                  " education",
-                  " computer vision",
-                  "developer tools"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2015
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  0,
-                  4,
-                  5,
-                  6,
-                  5
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5087283272744960/",
-            "name": "Jenkins project",
-            "tech": [
-                  "java",
-                  "javascript",
-                  "docker",
-                  "kubernetes",
-                  "go"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "continuous integration",
-                  "continuous delivery",
-                  "developer tools",
-                  "devops",
-                  "automation"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  5,
-                  7
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6331892753760256/",
-            "name": "Joplin",
-            "tech": [
-                  "node.js",
-                  "electron",
-                  "react native",
-                  "terminal-kit",
-                  "react"
-            ],
-            "cat": "End User Applications",
-            "top": [
-                  "notes",
-                  "synchronisation",
-                  "sharing",
-                  "encryption",
-                  "cross-platform"
-            ],
-            "year": [
-                  2020
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5566516864483328/",
-            "name": "Kapitan",
-            "tech": [
-                  "kubernetes",
-                  "jsonnet",
-                  "python 3",
-                  "jinja2",
-                  "terraform"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "programming languages",
-                  "great developer tooling",
-                  " cloud",
-                  "kubernetes"
-            ],
-            "year": [
-                  2020,
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  1
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4992468447133696/",
-            "name": "KDE Community",
-            "tech": [
-                  "c++",
-                  "qt",
-                  "c",
-                  "opencv"
-            ],
-            "cat": "End User Applications",
-            "top": [
-                  "vr",
-                  "graphics",
-                  "applications"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  17,
-                  22,
-                  19
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5280668067561472/",
-            "name": "Kiwix",
-            "tech": [
-                  "python 3",
-                  "c/c++",
-                  "javascript",
-                  "node.js",
-                  "kotlin"
-            ],
-            "cat": "Web",
-            "top": [
-                  "offline access"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  2,
-                  3
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6555254004383744/",
-            "name": "Kodi Foundation",
-            "tech": [
-                  "ffmpeg",
-                  "python",
-                  "c++",
-                  "sqlite",
-                  "mysql"
-            ],
-            "cat": "End User Applications",
-            "top": [
-                  "media",
-                  "video",
-                  "audio",
-                  "games"
-            ],
-            "year": [
-                  2020,
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  3
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5374310232883200/",
-            "name": "Kubeflow",
-            "tech": [
-                  "python",
-                  "jupyter notebook",
-                  "tensorflow",
-                  "kustomize",
-                  "kubernetes"
-            ],
-            "cat": "Cloud",
-            "top": [
-                  "machine learning",
-                  "infrastructure",
-                  "cloud",
-                  "kubernetes"
-            ],
-            "year": [
-                  2020
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6003184142647296/",
-            "name": "LabLua",
-            "tech": [
-                  "lua",
-                  "c\u00e9u",
-                  "lunatik",
-                  "pallene"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "scripting languages",
-                  "reactive programming",
-                  "compilers",
-                  "operating systems"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2016,
-                  2015,
-                  2014
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  4,
-                  6,
-                  8,
-                  6,
-                  5,
-                  5,
-                  6
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6184201612689408/",
-            "name": "Libre Space Foundation",
-            "tech": [
-                  "python",
-                  "django",
-                  "sdr",
-                  "embedded",
-                  "space applications"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "space applications",
-                  "spacecraft",
-                  "space standards",
-                  "satellite data"
-            ],
-            "year": [
-                  2020,
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  2
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5842452507787264/",
-            "name": "LibreHealth",
-            "tech": [
-                  "java",
-                  "javascript",
-                  "python 3",
-                  "android",
-                  "php"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "web",
-                  "radiology",
-                  "mobile-apps",
-                  "information security",
-                  "deep learning"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  4,
-                  9,
-                  0,
-                  4
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6094595844210688/",
-            "name": "LibreOffice",
-            "tech": [
-                  "c++",
-                  "python",
-                  "java"
-            ],
-            "cat": "End User Applications",
-            "top": [
-                  "office suite",
-                  " end-user application",
-                  "desktop application",
-                  "android"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2016,
-                  2015,
-                  2014,
-                  2013,
-                  2012,
-                  2011
-            ],
-            "project": [
-                  0,
-                  0,
-                  7,
-                  9,
-                  11,
-                  10,
-                  10,
-                  9,
-                  9,
-                  7,
-                  6,
-                  6
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5067783886340096/",
-            "name": "libvirt",
-            "tech": [
-                  "kvm",
-                  "xen",
-                  "hypervisor",
-                  "c",
-                  "python"
-            ],
-            "cat": "Cloud",
-            "top": [
-                  "virtualization",
-                  "library"
-            ],
-            "year": [
-                  2020,
-                  2018,
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  2,
-                  0,
-                  4
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6500210139725824/",
-            "name": "Linkerd",
-            "tech": [
-                  "linkerd",
-                  "kubernetes",
-                  "golang",
-                  "rust"
-            ],
-            "cat": "Cloud",
-            "top": [
-                  "service mesh",
-                  "cloud infrastructure",
-                  "microservices",
-                  "containers",
-                  " networking"
-            ],
-            "year": [
-                  2020,
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  2
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6406567974404096/",
-            "name": "Liquid Galaxy project",
-            "tech": [
-                  "python",
-                  "vue",
-                  "html",
-                  "javascript",
-                  "java"
-            ],
-            "cat": "Graphics / Video / Audio / Virtual Reality",
-            "top": [
-                  "maps",
-                  "machine learning",
-                  "graphics",
-                  "visualization",
-                  "data visualization"
-            ],
-            "year": [
-                  2020,
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  7,
-                  8
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6088258989064192/",
-            "name": "lowRISC",
-            "tech": [
-                  "systemverilog",
-                  "c++",
-                  "fpga",
-                  "python",
-                  "risc-v"
-            ],
-            "cat": "Other",
-            "top": [
-                  "open hardware",
-                  "compilers"
-            ],
-            "year": [
-                  2020,
-                  2017,
-                  2016,
-                  2015
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  4,
-                  4,
-                  0,
-                  0,
-                  2
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4588406077652992/",
-            "name": "MacPorts",
-            "tech": [
-                  "tcl",
-                  "c",
-                  "python",
-                  "scripting",
-                  "buildbot"
-            ],
-            "cat": "End User Applications",
-            "top": [
-                  "package management",
-                  "macos",
-                  "build tools",
-                  "libraries"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2013
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  4,
-                  1
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5950846174494720/",
-            "name": "MariaDB Foundation",
-            "tech": [
-                  "mariadb",
-                  "mysql",
-                  "c",
-                  "c++",
-                  "java"
-            ],
-            "cat": "Data and Databases",
-            "top": [
-                  "databases",
-                  "sql",
-                  "performance",
-                  " distributed systems"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  4,
-                  2
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6400769936326656/",
-            "name": "Matrix",
-            "tech": [
-                  "python",
-                  "javascript",
-                  "rust",
-                  "go",
-                  "react"
-            ],
-            "cat": "Social / Communications",
-            "top": [
-                  "encryption",
-                  "realtime communication",
-                  "decentralised",
-                  "team chat",
-                  "chat"
-            ],
-            "year": [
-                  2020
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  6
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4670622791106560/",
-            "name": "MBDyn",
-            "tech": [
-                  "c++",
-                  "python"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "mechanical engineering",
-                  "aeronautics",
-                  "automotive",
-                  "multibody dynamics",
-                  "scientific computing"
-            ],
-            "year": [
-                  2020,
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0,
-                  0,
-                  1
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5997649305534464/",
-            "name": "MDAnalysis",
-            "tech": [
-                  "python",
-                  "cython",
-                  "numpy",
-                  "c/c++"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "biophysics",
-                  "computational chemistry",
-                  "molecular simulation",
-                  "cheminformatics",
-                  "molecular dynamics"
-            ],
-            "year": [
-                  2020
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5387896221073408/",
-            "name": "MetaBrainz Foundation Inc.",
-            "tech": [
-                  "python",
-                  "postgres",
-                  "solr",
-                  "perl",
-                  "spark"
-            ],
-            "cat": "Data and Databases",
-            "top": [
-                  "music",
-                  "books",
-                  "metadata",
-                  "community",
-                  "open data"
-            ],
-            "year": [
-                  2020,
-                  2018,
-                  2017,
-                  2015,
-                  2014,
-                  2013,
-                  2012,
-                  2011,
-                  2010
-            ],
-            "project": [
-                  0,
-                  3,
-                  2,
-                  4,
-                  3,
-                  5,
-                  4,
-                  0,
-                  5,
-                  5,
-                  0,
-                  7
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4999193090850816/",
-            "name": "Metasploit",
-            "tech": [
-                  "ruby",
-                  "postgresql",
-                  "python",
-                  "c",
-                  "assembly"
-            ],
-            "cat": "Security",
-            "top": [
-                  "security",
-                  "penetration testing",
-                  "offensive security",
-                  "exploitation"
-            ],
-            "year": [
-                  2020,
-                  2018,
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  5,
-                  0,
-                  2
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4721222438354944/",
-            "name": "MGGG Redistricting Lab",
-            "tech": [
-                  "python",
-                  "javascript",
-                  "gis",
-                  "julia",
-                  "mapping"
-            ],
-            "cat": "End User Applications",
-            "top": [
-                  "web-interface",
-                  "statistics",
-                  "graph algorithms",
-                  "mapping",
-                  "civic tech"
-            ],
-            "year": [
-                  2020
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6125092997693440/",
-            "name": "MIT App Inventor",
-            "tech": [
-                  "javascript",
-                  "java",
-                  "google web toolkit",
-                  "android",
-                  "junit"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "education",
-                  "mobile",
-                  "web",
-                  "apps",
-                  "development"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  4,
-                  0,
-                  4,
-                  6
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5847122345197568/",
-            "name": "Mixxx",
-            "tech": [
-                  "c++",
-                  "qt",
-                  "javascript",
-                  "deep learning"
-            ],
-            "cat": "End User Applications",
-            "top": [
-                  "music",
-                  "dj",
-                  "streaming",
-                  "music information retrieval"
-            ],
-            "year": [
-                  2020,
-                  2011
-            ],
-            "project": [
-                  0,
-                  0,
-                  3,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5279502554365952/",
-            "name": "mlpack",
-            "tech": [
-                  "c++",
-                  "python",
-                  "templates",
-                  "machine learning",
-                  "deep learning"
-            ],
-            "cat": "Data and Databases",
-            "top": [
-                  "machine learning",
-                  "optimization",
-                  "data science",
-                  "neighbor-search",
-                  "reinforcement learning"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  10,
-                  6,
-                  9,
-                  8
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5420871000260608/",
-            "name": "Moira",
-            "tech": [
-                  "golang",
-                  "javascript",
-                  "typescript",
-                  "graphite",
-                  "react"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "devops",
-                  "monitoring",
-                  "alerting",
-                  "devtools",
-                  "sre"
-            ],
-            "year": [
-                  2020,
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  2
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5486699158700032/",
-            "name": "MoveIt",
-            "tech": [
-                  "c++",
-                  "ros"
-            ],
-            "cat": "Other",
-            "top": [
-                  "robotics"
-            ],
-            "year": [
-                  2020
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5169365365817344/",
-            "name": "Mozilla",
-            "tech": [
-                  "javascript",
-                  "rust",
-                  "html5",
-                  "web development",
-                  "python"
-            ],
-            "cat": "Web",
-            "top": [
-                  "web browser",
-                  "devtools",
-                  "information security",
-                  "open source"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2016,
-                  2014,
-                  2013,
-                  2012,
-                  2011,
-                  2010
-            ],
-            "project": [
-                  0,
-                  10,
-                  11,
-                  16,
-                  20,
-                  25,
-                  0,
-                  13,
-                  21,
-                  16,
-                  14,
-                  11
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5017312551239680/",
-            "name": "MuseScore",
-            "tech": [
-                  "c++",
-                  "qt",
-                  "qml",
-                  "cmake"
-            ],
-            "cat": "End User Applications",
-            "top": [
-                  "music",
-                  "notation software",
-                  "piano",
-                  "guitar"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2016,
-                  2014,
-                  2013
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  5,
-                  0,
-                  3,
-                  3,
-                  3,
-                  4,
-                  3
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5440234189225984/",
-            "name": "mypy",
-            "tech": [
-                  "python"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "static code analysis\u00e2\u20ac\u017d",
-                  "compiler"
-            ],
-            "year": [
-                  2020
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6328123651522560/",
-            "name": "MZmine",
-            "tech": [
-                  "java",
-                  "javafx"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "mass spectrometry",
-                  "molecular analysis",
-                  "visualization",
-                  "data processing",
-                  "molecular networking"
-            ],
-            "year": [
-                  2020
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4549302816342016/",
-            "name": "National Resource for Network Biology (NRNB)",
-            "tech": [
-                  "java",
-                  "javascript",
-                  "python",
-                  "r",
-                  "rest"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "network biology",
-                  "graphics",
-                  "web application",
-                  "scientific computing",
-                  "data science"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2016,
-                  2014,
-                  2013,
-                  2012
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  16,
-                  14,
-                  17,
-                  0,
-                  15,
-                  20,
-                  10,
-                  11,
-                  15
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6636241820319744/",
-            "name": "Neovim",
-            "tech": [
-                  "c",
-                  "lua",
-                  "rpc"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "editor",
-                  "programming"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  2,
-                  1
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5983819074633728/",
-            "name": "Netty",
-            "tech": [
-                  "java",
-                  "jni",
-                  "c"
-            ],
-            "cat": "Web",
-            "top": [
-                  "nonblocking",
-                  "network",
-                  "async"
-            ],
-            "year": [
-                  2020
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6692416771325952/",
-            "name": "NumFOCUS",
-            "tech": [
-                  "python",
-                  "c/c++",
-                  "javascript",
-                  "r",
-                  "julia"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "scientific computing",
-                  "graphics",
-                  "data science",
-                  "numerical computing"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2016,
-                  2015
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  7,
-                  10,
-                  40,
-                  19,
-                  28
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5653128168341504/",
-            "name": "NV Access",
-            "tech": [
-                  "python",
-                  "c++",
-                  "ui automation",
-                  "iaccessible2",
-                  "win32 api"
-            ],
-            "cat": "Other",
-            "top": [
-                  "accessibility",
-                  " blindness",
-                  " screen reader",
-                  " braille",
-                  " text to speech"
-            ],
-            "year": [
-                  2020,
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  1
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4595548239167488/",
-            "name": "Open Bioinformatics Foundation (OBF)",
-            "tech": [
-                  "python",
-                  "javascript",
-                  "c/c++"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "bioinformatics",
-                  "computational biology"
-            ],
-            "year": [
-                  2020
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  8
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5796522697949184/",
-            "name": "Open Chemistry",
-            "tech": [
-                  "c/c++",
-                  "python",
-                  "javascript",
-                  "opengl",
-                  "html"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "scientific visualization",
-                  " scientific computing",
-                  "computational chemistry",
-                  " data science",
-                  "cheminformatics"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  6,
-                  7,
-                  6,
-                  5
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5089985813807104/",
-            "name": "Open Genome Informatics",
-            "tech": [
-                  "neo4j",
-                  "python",
-                  "javascript",
-                  "react",
-                  "r-project"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "computational biology",
-                  "biology",
-                  " genomics",
-                  " bioinformatics",
-                  "data and databases"
-            ],
-            "year": [
-                  2020,
-                  2017,
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  6,
-                  8,
-                  0,
-                  0,
-                  5
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4541796253696000/",
-            "name": "Open Roberta",
-            "tech": [
-                  "java",
-                  "javascript"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  " education",
-                  "web",
-                  "visual programming",
-                  " robotics"
-            ],
-            "year": [
-                  2020,
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  3
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5551857973329920/",
-            "name": "Open Source Robotics Foundation",
-            "tech": [
-                  "ros",
-                  "gazebo",
-                  "c++",
-                  "python"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "robotics"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2016,
-                  2015,
-                  2014,
-                  2013
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  5,
-                  6,
-                  7,
-                  0,
-                  4,
-                  7,
-                  7
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4577601315667968/",
-            "name": "OpenAstronomy",
-            "tech": [
-                  "python",
-                  "julia",
-                  "spark",
-                  "numba",
-                  "javascript"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "astronomy",
-                  "solar physics",
-                  "orbital mechanics",
-                  "high energy astrophysics",
-                  "cloud infrastructure"
-            ],
-            "year": [
-                  2020,
-                  2018,
-                  2017,
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  7,
-                  8,
-                  8,
-                  0,
-                  10
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6410072298618880/",
-            "name": "OpenCV",
-            "tech": [
-                  "c/c++",
-                  "python 3",
-                  "javascript",
-                  "cuda"
-            ],
-            "cat": "Graphics / Video / Audio / Virtual Reality",
-            "top": [
-                  "computer vision",
-                  "deep learning",
-                  "machine learning",
-                  "robotics",
-                  "graphics"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2017,
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  11,
-                  15,
-                  0,
-                  8,
-                  14
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6277255937916928/",
-            "name": "OpenEMR",
-            "tech": [
-                  "php",
-                  "mysql",
-                  "javascript",
-                  "docker",
-                  "html"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "medical records",
-                  "health",
-                  "cloud",
-                  "medicine",
-                  "medical practice management solution"
-            ],
-            "year": [
-                  2020
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6405402461208576/",
-            "name": "OpenHMD",
-            "tech": [
-                  "c99",
-                  "opengl",
-                  "vulkan",
-                  "opencv",
-                  "libusb"
-            ],
-            "cat": "Graphics / Video / Audio / Virtual Reality",
-            "top": [
-                  "virtual reality",
-                  "xr",
-                  "drivers",
-                  "reverse engineering",
-                  "computer vision"
-            ],
-            "year": [
-                  2020
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5934410743939072/",
-            "name": "OpenMined",
-            "tech": [
-                  "deep learning",
-                  "federated learning",
-                  "homomorphic encryption",
-                  "secure multi-party computation",
-                  "differential privacy"
-            ],
-            "cat": "Other",
-            "top": [
-                  "privacy",
-                  "artificial intelligence"
-            ],
-            "year": [
-                  2020
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  4
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6119294959616000/",
-            "name": "OpenMRS",
-            "tech": [
-                  "java",
-                  "javascript",
-                  "spring",
-                  "mysql",
-                  "android"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "science and medicine",
-                  "open source medical records",
-                  " developing countries"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2016,
-                  2015,
-                  2014,
-                  2013,
-                  2012,
-                  2011,
-                  2010,
-                  2009
-            ],
-            "project": [
-                  12,
-                  13,
-                  15,
-                  17,
-                  11,
-                  12,
-                  14,
-                  9,
-                  15,
-                  10,
-                  12,
-                  9
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6727913602285568/",
-            "name": "OpenRefine",
-            "tech": [
-                  "java",
-                  "javascript"
-            ],
-            "cat": "Data and Databases",
-            "top": [
-                  "real-time",
-                  "data visualization",
-                  " data integration",
-                  "web application"
-            ],
-            "year": [
-                  2020
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5531645890789376/",
-            "name": "OpenStreetMap",
-            "tech": [
-                  "javascript",
-                  "java",
-                  "python",
-                  "sql",
-                  "docker"
-            ],
-            "cat": "Data and Databases",
-            "top": [
-                  "maps",
-                  "open data",
-                  "crowdsourcing",
-                  "gis"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2016,
-                  2015,
-                  2012,
-                  2011,
-                  2010,
-                  2009
-            ],
-            "project": [
-                  6,
-                  6,
-                  3,
-                  5,
-                  0,
-                  0,
-                  7,
-                  4,
-                  5,
-                  5,
-                  5,
-                  4
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5703501222510592/",
-            "name": "openSUSE Project",
-            "tech": [
-                  "linux",
-                  "python",
-                  "perl",
-                  "rpm",
-                  "javascript"
-            ],
-            "cat": "Operating Systems",
-            "top": [
-                  "tools",
-                  "operating systems",
-                  "software quality",
-                  "build tools",
-                  "containers"
-            ],
-            "year": [
-                  2020,
-                  2011,
-                  2009
-            ],
-            "project": [
-                  6,
-                  0,
-                  13,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4717183558483968/",
-            "name": "OpenWISP",
-            "tech": [
-                  "python",
-                  "django",
-                  "openwrt",
-                  "javascript",
-                  "lua"
-            ],
-            "cat": "Web",
-            "top": [
-                  "iot",
-                  " networking",
-                  "network visualization",
-                  "wireless networks",
-                  "network automation"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  5,
-                  2,
-                  2,
-                  3
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4686040649957376/",
-            "name": "Oppia Foundation",
-            "tech": [
-                  "angular",
-                  "python",
-                  "css",
-                  "kotlin",
-                  "webpack"
-            ],
-            "cat": "Web",
-            "top": [
-                  "education",
-                  " web",
-                  " interactive",
-                  " tools",
-                  " community"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  3,
-                  7,
-                  4,
-                  12
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6216078121762816/",
-            "name": "Orcasound",
-            "tech": [
-                  "elixir",
-                  "react",
-                  "javascript",
-                  "python",
-                  "raspberry pi"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "real-time",
-                  "audio",
-                  "citizen science",
-                  "machine learning",
-                  "web application"
-            ],
-            "year": [
-                  2020
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5355444958134272/",
-            "name": "OSGeo",
-            "tech": [
-                  "c/c++",
-                  "python",
-                  "sql",
-                  "open source databases",
-                  "java"
-            ],
-            "cat": "Other",
-            "top": [
-                  "gis",
-                  "geolocation",
-                  " mapping",
-                  " open science",
-                  "citizen science"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  13,
-                  10,
-                  7,
-                  10
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5260035782868992/",
-            "name": "OWASP Foundation",
-            "tech": [
-                  "python",
-                  "javascript",
-                  ".net",
-                  "node.js"
-            ],
-            "cat": "Security",
-            "top": [
-                  "application security",
-                  "web application security",
-                  "information security",
-                  "cyber security"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2016,
-                  2014,
-                  2012
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  4,
-                  0,
-                  16,
-                  0,
-                  5,
-                  0,
-                  8,
-                  12,
-                  12
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4860868635918336/",
-            "name": "PEcAn Project",
-            "tech": [
-                  "r",
-                  "python",
-                  "docker",
-                  "postgresql",
-                  "kubernetes"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "ecosystem models",
-                  "scientific visualization",
-                  "ecological forecasting",
-                  "data science",
-                  "climate science"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  1,
-                  2,
-                  3
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5002697415065600/",
-            "name": "Percona",
-            "tech": [
-                  "javascript",
-                  "shell script",
-                  "golang",
-                  "prometheus",
-                  "grafana"
-            ],
-            "cat": "Data and Databases",
-            "top": [
-                  "data visualization",
-                  "automation",
-                  "load testing",
-                  "alerts",
-                  "testing"
-            ],
-            "year": [
-                  2020,
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  1
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5233572744527872/",
-            "name": "Performance Co-Pilot",
-            "tech": [
-                  "c",
-                  "redis",
-                  "grafana",
-                  "rest",
-                  "libuv"
-            ],
-            "cat": "Operating Systems",
-            "top": [
-                  "performance",
-                  "analysis",
-                  "distributed",
-                  "timeseries",
-                  "lightweight"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  5,
-                  5,
-                  2,
-                  3
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6385935689711616/",
-            "name": "Pitivi",
-            "tech": [
-                  "gtk",
-                  "gstreamer",
-                  "c",
-                  "python 3"
-            ],
-            "cat": "Graphics / Video / Audio / Virtual Reality",
-            "top": [
-                  "filmmaking",
-                  " video editing",
-                  " video processing"
-            ],
-            "year": [
-                  2020,
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  3
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6128597321908224/",
-            "name": "Point Cloud Library",
-            "tech": [
-                  "cpp",
-                  "cmake",
-                  "devops"
-            ],
-            "cat": "Graphics / Video / Audio / Virtual Reality",
-            "top": [
-                  "3d computer vision",
-                  " robotics",
-                  "perception"
-            ],
-            "year": [
-                  2020
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6566134096068608/",
-            "name": "PostgreSQL",
-            "tech": [
-                  "postgresql",
-                  "postgres",
-                  "sql",
-                  "c",
-                  "perl"
-            ],
-            "cat": "Data and Databases",
-            "top": [
-                  "data",
-                  "database",
-                  "rdbms",
-                  "sql",
-                  "data management"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2010
-            ],
-            "project": [
-                  0,
-                  5,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  4,
-                  3,
-                  4,
-                  3
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5654790253576192/",
-            "name": "Postman",
-            "tech": [
-                  "node.js",
-                  "javascript"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "api management",
-                  " developer tools",
-                  "api",
-                  "programmer productivity"
-            ],
-            "year": [
-                  2020
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5988762313555968/",
-            "name": "Processing Foundation",
-            "tech": [
-                  "python",
-                  "android",
-                  "opengl",
-                  "java",
-                  "javascript"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "creative coding",
-                  "graphics",
-                  "web",
-                  " education",
-                  "design"
-            ],
-            "year": [
-                  2020
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  11
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5158498192588800/",
-            "name": "Purr Data",
-            "tech": [
-                  "html5",
-                  "javascript",
-                  "opengl",
-                  "svg",
-                  "c/c++"
-            ],
-            "cat": "Graphics / Video / Audio / Virtual Reality",
-            "top": [
-                  "real-time",
-                  "audio",
-                  "2d/3d graphics",
-                  "visual programming",
-                  "music"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  1,
-                  3
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6706162411503616/",
-            "name": "Python Software Foundation",
-            "tech": [
-                  "python"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "security",
-                  "machine learning",
-                  "ui design",
-                  "science"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2016,
-                  2015,
-                  2014,
-                  2013,
-                  2012,
-                  2011,
-                  2010,
-                  2009
-            ],
-            "project": [
-                  25,
-                  31,
-                  30,
-                  26,
-                  33,
-                  40,
-                  62,
-                  49,
-                  29,
-                  14,
-                  30,
-                  24
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6231608723505152/",
-            "name": "QEMU",
-            "tech": [
-                  "linux",
-                  "kvm",
-                  "c",
-                  "virtualization",
-                  "rust"
-            ],
-            "cat": "Cloud",
-            "top": [
-                  "emulator",
-                  "hypervisor",
-                  "lowlevel",
-                  "code generation",
-                  "compiler"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2016,
-                  2015,
-                  2014
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  6,
-                  7,
-                  6,
-                  4,
-                  4,
-                  3,
-                  3
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4924517870206976/",
-            "name": "Qubes OS",
-            "tech": [
-                  "c",
-                  "python",
-                  "xen",
-                  "shell",
-                  "linux"
-            ],
-            "cat": "Operating Systems",
-            "top": [
-                  "virtualization",
-                  "operating systems",
-                  "security",
-                  "privacy"
-            ],
-            "year": [
-                  2020,
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0,
-                  0,
-                  1
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4761521042751488/",
-            "name": "R Project for Statistical Computing",
-            "tech": [
-                  "r-project",
-                  "c",
-                  "c++",
-                  "fortran",
-                  "javascript"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "data science",
-                  "data visualization",
-                  "statistics",
-                  "graphics",
-                  "machine learning"
-            ],
-            "year": [
-                  2020,
-                  2015,
-                  2014,
-                  2010
-            ],
-            "project": [
-                  0,
-                  4,
-                  0,
-                  0,
-                  0,
-                  17,
-                  23,
-                  0,
-                  0,
-                  0,
-                  0,
-                  20
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6102444192301056/",
-            "name": "Radare",
-            "tech": [
-                  "c",
-                  "c++",
-                  "python",
-                  "go",
-                  "qt"
-            ],
-            "cat": "Security",
-            "top": [
-                  "reverse engineering",
-                  "disassembly",
-                  "debugging",
-                  "program analysis"
-            ],
-            "year": [
-                  2020
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  4
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5352970822090752/",
-            "name": "ReactOS",
-            "tech": [
-                  "c",
-                  "c++",
-                  "win32",
-                  "nt"
-            ],
-            "cat": "Operating Systems",
-            "top": [
-                  "operating systems",
-                  "drivers",
-                  "kernel",
-                  "windows",
-                  "applications"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2016,
-                  2011
-            ],
-            "project": [
-                  0,
-                  0,
-                  4,
-                  0,
-                  0,
-                  0,
-                  0,
-                  4,
-                  4,
-                  1,
-                  2,
-                  3
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6243181680656384/",
-            "name": "Red Hen Lab",
-            "tech": [
-                  "nlp",
-                  "asr",
-                  "opencv",
-                  "machine learning",
-                  "data science"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "multimedia",
-                  "data science",
-                  "communication",
-                  "big data",
-                  "cognitive science"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2016,
-                  2015
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  5,
-                  9,
-                  10,
-                  15,
-                  8
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6622081011154944/",
-            "name": "RoboComp",
-            "tech": [
-                  "python",
-                  "c++11",
-                  "component-based development",
-                  "qt",
-                  "opencv"
-            ],
-            "cat": "Other",
-            "top": [
-                  "robotics",
-                  " computer vision",
-                  " multi-agent system",
-                  " component-based development"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2015,
-                  2013
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0,
-                  4,
-                  0,
-                  9,
-                  8,
-                  10,
-                  10
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4707433043197952/",
-            "name": "Rocket.Chat",
-            "tech": [
-                  "javascript",
-                  "react",
-                  "reactnative",
-                  "chatbots",
-                  "ruby"
-            ],
-            "cat": "Social / Communications",
-            "top": [
-                  "social-network",
-                  "communication",
-                  "collaboration",
-                  "team chat",
-                  "instant messaging"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  4,
-                  7,
-                  15,
-                  7
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4511020028002304/",
-            "name": "RTEMS Project",
-            "tech": [
-                  "c/c++",
-                  "python",
-                  "assembly",
-                  "posix",
-                  "bsd unix"
-            ],
-            "cat": "Operating Systems",
-            "top": [
-                  "real time",
-                  " kernel",
-                  " embedded systems",
-                  " multicore",
-                  " iot cps"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2016,
-                  2015,
-                  2014,
-                  2013,
-                  2012,
-                  2011,
-                  2010,
-                  2009
-            ],
-            "project": [
-                  6,
-                  8,
-                  8,
-                  10,
-                  8,
-                  5,
-                  9,
-                  5,
-                  4,
-                  4,
-                  4,
-                  5
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5633129894641664/",
-            "name": "Ruby",
-            "tech": [
-                  "ruby",
-                  "c",
-                  "java"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "programming language",
-                  " developer tools",
-                  " web servers",
-                  "cloud"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2016,
-                  2015
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  6,
-                  12,
-                  0,
-                  5,
-                  5,
-                  4
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6190385258299392/",
-            "name": "SageMath",
-            "tech": [
-                  "python",
-                  "cython"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "mathematics",
-                  " education",
-                  " research",
-                  " math"
-            ],
-            "year": [
-                  2020,
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  4,
-                  5
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5671203068444672/",
-            "name": "Samba",
-            "tech": [
-                  "smb",
-                  "cifs",
-                  "c",
-                  "python"
-            ],
-            "cat": "Data and Databases",
-            "top": [
-                  " networking"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2017,
-                  2014,
-                  2013,
-                  2012,
-                  2011,
-                  2010,
-                  2009
-            ],
-            "project": [
-                  3,
-                  3,
-                  4,
-                  3,
-                  3,
-                  3,
-                  0,
-                  0,
-                  1,
-                  0,
-                  1,
-                  1
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5384571547287552/",
-            "name": "SCoRe Lab",
-            "tech": [
-                  "python",
-                  "mobile",
-                  "cloud",
-                  "web development",
-                  "machine learning"
-            ],
-            "cat": "End User Applications",
-            "top": [
-                  "information security",
-                  "mobile",
-                  "cloud",
-                  "web development",
-                  "machine learning"
-            ],
-            "year": [
-                  2020
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  25
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6265295930392576/",
-            "name": "ScummVM",
-            "tech": [
-                  "c++",
-                  "sdl",
-                  "opengl",
-                  "assembly",
-                  "lua"
-            ],
-            "cat": "End User Applications",
-            "top": [
-                  "games",
-                  " game engines",
-                  " software preservation",
-                  " software archeology"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2016,
-                  2014,
-                  2013,
-                  2012,
-                  2011,
-                  2010,
-                  2009
-            ],
-            "project": [
-                  4,
-                  4,
-                  1,
-                  3,
-                  4,
-                  5,
-                  0,
-                  3,
-                  2,
-                  3,
-                  3,
-                  4
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4722091934351360/",
-            "name": "Shogun",
-            "tech": [
-                  "python",
-                  "c++",
-                  "data science",
-                  "machine learning",
-                  "matlab"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "machine learning",
-                  " scientific computing",
-                  " software engineering",
-                  " user experience",
-                  " data science"
-            ],
-            "year": [
-                  2020
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6283949946437632/",
-            "name": "SPDX",
-            "tech": [
-                  "python",
-                  "java",
-                  "golang",
-                  "node.js",
-                  "xml"
-            ],
-            "cat": "Other",
-            "top": [
-                  "open source",
-                  "compliance",
-                  "licensing"
-            ],
-            "year": [
-                  2020,
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  4,
-                  0,
-                  4
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6742658493448192/",
-            "name": "Ste||ar group",
-            "tech": [
-                  "cpp",
-                  "hpx",
-                  "python",
-                  "hpc",
-                  "cuda"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "high performance computing",
-                  "asynchronous manytask systems",
-                  "machine learning",
-                  "deep learning"
-            ],
-            "year": [
-                  2020
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  5
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5627435304878080/",
-            "name": "strace",
-            "tech": [
-                  "linux",
-                  "c",
-                  "shell",
-                  "make",
-                  "awk"
-            ],
-            "cat": "Operating Systems",
-            "top": [
-                  "diagnostic",
-                  "debugging",
-                  "tracing"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2016,
-                  2015,
-                  2014
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  1,
-                  4,
-                  4,
-                  2,
-                  2,
-                  1
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5702344097923072/",
-            "name": "Submitty",
-            "tech": [
-                  "php",
-                  "python",
-                  "postgresql",
-                  "c++",
-                  "javascript"
-            ],
-            "cat": "Other",
-            "top": [
-                  "education",
-                  "web",
-                  "communication",
-                  "visualization",
-                  "privacy/security"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  4,
-                  3
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6305701137219584/",
-            "name": "Sugar Labs",
-            "tech": [
-                  "python",
-                  "javascript",
-                  "gtk",
-                  "pygame",
-                  "c"
-            ],
-            "cat": "End User Applications",
-            "top": [
-                  "education"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2016,
-                  2015,
-                  2014,
-                  2013,
-                  2010
-            ],
-            "project": [
-                  0,
-                  3,
-                  0,
-                  0,
-                  7,
-                  9,
-                  5,
-                  5,
-                  9,
-                  11,
-                  8,
-                  9
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4543471290941440/",
-            "name": "Swift",
-            "tech": [
-                  "swift",
-                  "c++"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "developer tools",
-                  "programming languages"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  4
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5628676583981056/",
-            "name": "SymbiFlow",
-            "tech": [
-                  "c/c++",
-                  "fpga",
-                  "python",
-                  "verilog"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "fpga",
-                  "programming languages and development tools"
-            ],
-            "year": [
-                  2020,
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  3
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5669371197784064/",
-            "name": "SymPy",
-            "tech": [
-                  "python"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "mathematics",
-                  "symbolic mathematics",
-                  "physics"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2016,
-                  2014,
-                  2013,
-                  2012,
-                  2011
-            ],
-            "project": [
-                  0,
-                  0,
-                  9,
-                  6,
-                  7,
-                  10,
-                  0,
-                  7,
-                  8,
-                  7,
-                  10,
-                  6
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5710829074251776/",
-            "name": "Synfig",
-            "tech": [
-                  "c++",
-                  "gtk",
-                  "gtkmm",
-                  "python"
-            ],
-            "cat": "Graphics / Video / Audio / Virtual Reality",
-            "top": [
-                  "vector graphics",
-                  "animation",
-                  "2d/3d graphics"
-            ],
-            "year": [
-                  2020,
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  2
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6013743185526784/",
-            "name": "syslog-ng",
-            "tech": [
-                  "elasticsearch",
-                  "kafka",
-                  "sql",
-                  "python",
-                  "c"
-            ],
-            "cat": "Other",
-            "top": [
-                  " cloud",
-                  "logging",
-                  "high performance data processing",
-                  "reliable log transfer",
-                  "data processing pipeline"
-            ],
-            "year": [
-                  2020,
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  1
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6024226160508928/",
-            "name": "TARDIS-SN",
-            "tech": [
-                  "python"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "astronomy",
-                  "supernova",
-                  "science"
-            ],
-            "year": [
-                  2020,
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  0,
-                  0,
-                  0,
-                  3
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5569649606918144/",
-            "name": "TensorFlow",
-            "tech": [
-                  "machine learning",
-                  "deep learning",
-                  "python",
-                  "data analysis",
-                  "c/c++"
-            ],
-            "cat": "Other",
-            "top": [
-                  "deep learning",
-                  "machine learning",
-                  "python",
-                  "data",
-                  "data science"
-            ],
-            "year": [
-                  2020,
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  19,
-                  17
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6679967372410880/",
-            "name": "The Apache Software Foundation",
-            "tech": [
-                  "java",
-                  "c++"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  " big data",
-                  "cloud",
-                  "libraries"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2009
-            ],
-            "project": [
-                  32,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  17,
-                  17
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5461276207087616/",
-            "name": "The GNU Project",
-            "tech": [
-                  "c/c++",
-                  "javascript",
-                  "android",
-                  "python",
-                  "scheme"
-            ],
-            "cat": "Operating Systems",
-            "top": [
-                  "http",
-                  "operating systems",
-                  "package managers",
-                  "astronomy",
-                  "reverse engineering"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2017,
-                  2010
-            ],
-            "project": [
-                  0,
-                  14,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  13,
-                  0,
-                  5,
-                  7
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5961706703945728/",
-            "name": "The Honeynet Project",
-            "tech": [
-                  "python",
-                  "golang",
-                  "honeypot",
-                  "machine learning",
-                  "networking"
-            ],
-            "cat": "Security",
-            "top": [
-                  "honeynets",
-                  "honeypots",
-                  "deception",
-                  "research",
-                  "malware"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2016,
-                  2015,
-                  2013,
-                  2012,
-                  2011,
-                  2010,
-                  2009
-            ],
-            "project": [
-                  9,
-                  16,
-                  12,
-                  15,
-                  13,
-                  0,
-                  7,
-                  11,
-                  12,
-                  17,
-                  9,
-                  11
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4643042893496320/",
-            "name": "The Java Pathfinder Team",
-            "tech": [
-                  "javajava",
-                  "jvm",
-                  "android",
-                  "distributed systems"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "program analysis",
-                  " test input generation",
-                  " model checking",
-                  " symbolic execution",
-                  " verification of concurrent systems"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2013,
-                  2012,
-                  2011,
-                  2010
-            ],
-            "project": [
-                  0,
-                  8,
-                  11,
-                  11,
-                  15,
-                  0,
-                  0,
-                  0,
-                  7,
-                  4,
-                  6,
-                  6
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6163109162516480/",
-            "name": "The Julia Language",
-            "tech": [
-                  "julia",
-                  "julialang"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "technical computing",
-                  "data science",
-                  "scientific computing",
-                  "machine learning",
-                  "numerical computing"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2017,
-                  2016,
-                  2014
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  0,
-                  10,
-                  16,
-                  0,
-                  13,
-                  15
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5398756750524416/",
-            "name": "The Libreswan Project",
-            "tech": [
-                  "c",
-                  "python"
-            ],
-            "cat": "Security",
-            "top": [
-                  "vpn",
-                  "ipsec",
-                  "ike"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  3,
-                  1,
-                  3
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5415607517839360/",
-            "name": "The Linux Foundation",
-            "tech": [
-                  "c",
-                  "c++",
-                  "cups",
-                  "ipp"
-            ],
-            "cat": "Operating Systems",
-            "top": [
-                  "automotive",
-                  "printing",
-                  "kernel",
-                  "lsb",
-                  "spdx"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2016,
-                  2014,
-                  2013,
-                  2012,
-                  2011,
-                  2010,
-                  2009
-            ],
-            "project": [
-                  7,
-                  11,
-                  12,
-                  14,
-                  14,
-                  15,
-                  0,
-                  11,
-                  11,
-                  12,
-                  7,
-                  13
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5902726635978752/",
-            "name": "The LLVM Compiler Infrastructure",
-            "tech": [
-                  "llvm",
-                  "clang",
-                  "mlir"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "compilers",
-                  "debuggers",
-                  "code analysis",
-                  "programming languages and development tools"
-            ],
-            "year": [
-                  2020,
-                  2016,
-                  2011
-            ],
-            "project": [
-                  0,
-                  0,
-                  7,
-                  0,
-                  0,
-                  0,
-                  0,
-                  7,
-                  0,
-                  0,
-                  0,
-                  15
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6055344943398912/",
-            "name": "The Mifos Initiative",
-            "tech": [
-                  "android",
-                  "java",
-                  "angular",
-                  "mysql",
-                  "spring"
-            ],
-            "cat": "End User Applications",
-            "top": [
-                  "fintech",
-                  "mobile banking",
-                  "cloud",
-                  "big data",
-                  "web"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  12,
-                  14,
-                  17
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6156737276542976/",
-            "name": "The NetBSD Foundation",
-            "tech": [
-                  "c",
-                  "bsd make"
-            ],
-            "cat": "Operating Systems",
-            "top": [
-                  "kernel",
-                  "userland",
-                  "unix",
-                  "packaging",
-                  "bsd"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2016,
-                  2013,
-                  2012,
-                  2011,
-                  2010
-            ],
-            "project": [
-                  0,
-                  6,
-                  8,
-                  6,
-                  4,
-                  0,
-                  0,
-                  4,
-                  3,
-                  4,
-                  7,
-                  6
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5105708816662528/",
-            "name": "The ns-3 Network Simulator Project",
-            "tech": [
-                  "c/c++",
-                  "python"
-            ],
-            "cat": "Other",
-            "top": [
-                  "research",
-                  " networking",
-                  "simulation"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2015,
-                  2014,
-                  2013,
-                  2012,
-                  2010,
-                  2009
-            ],
-            "project": [
-                  3,
-                  4,
-                  0,
-                  3,
-                  2,
-                  4,
-                  4,
-                  0,
-                  5,
-                  5,
-                  4,
-                  4
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4504833932918784/",
-            "name": "The Terasology Foundation",
-            "tech": [
-                  "java",
-                  "lwgjl",
-                  "opengl",
-                  "blender",
-                  "gradle"
-            ],
-            "cat": "End User Applications",
-            "top": [
-                  "games",
-                  "ai",
-                  "graphics",
-                  "voxel",
-                  "sandbox"
-            ],
-            "year": [
-                  2020,
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  9,
-                  8
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6331124088832000/",
-            "name": "The Wine Project",
-            "tech": [
-                  "c",
-                  "opengl",
-                  "directx",
-                  "win32",
-                  "vulkan"
-            ],
-            "cat": "Other",
-            "top": [
-                  "compatibility",
-                  " 3d",
-                  " directx",
-                  " opengl",
-                  "vulkan"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2016,
-                  2015,
-                  2014,
-                  2010,
-                  2009
-            ],
-            "project": [
-                  5,
-                  4,
-                  0,
-                  0,
-                  0,
-                  3,
-                  4,
-                  2,
-                  0,
-                  2,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6444776540340224/",
-            "name": "VideoLAN",
-            "tech": [
-                  "c++",
-                  "asm",
-                  "c",
-                  "go",
-                  "c#"
-            ],
-            "cat": "Graphics / Video / Audio / Virtual Reality",
-            "top": [
-                  "multimedia",
-                  " video processing",
-                  "vr",
-                  "audio",
-                  "video"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2011,
-                  2010,
-                  2009
-            ],
-            "project": [
-                  12,
-                  14,
-                  12,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  9,
-                  10,
-                  9,
-                  8
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5144337383424000/",
-            "name": "webpack",
-            "tech": [
-                  "javascript",
-                  "webpack"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "web development"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  2,
-                  1
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5593787323121664/",
-            "name": "Wikimedia Foundation",
-            "tech": [
-                  "html",
-                  "css",
-                  "python",
-                  "javascript",
-                  "php"
-            ],
-            "cat": "Web",
-            "top": [
-                  " mediawiki",
-                  " semantic web",
-                  " i18n",
-                  "wikipedia",
-                  "wikimedia"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2016,
-                  2015,
-                  2012,
-                  2011,
-                  2010,
-                  2009
-            ],
-            "project": [
-                  4,
-                  6,
-                  7,
-                  8,
-                  0,
-                  0,
-                  8,
-                  6,
-                  7,
-                  12,
-                  11,
-                  14
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5630325851422720/",
-            "name": "Wireshark",
-            "tech": [
-                  "qt",
-                  "c/c++",
-                  "lua",
-                  "pcap",
-                  "cmake"
-            ],
-            "cat": "Security",
-            "top": [
-                  "network monitoring",
-                  "data visualization",
-                  "network security"
-            ],
-            "year": [
-                  2020,
-                  2013
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5883488672153600/",
-            "name": "X.Org Foundation",
-            "tech": [
-                  "x11",
-                  "opencl",
-                  "opengl",
-                  "wayland",
-                  "vulkan"
-            ],
-            "cat": "Graphics / Video / Audio / Virtual Reality",
-            "top": [
-                  "graphics stack",
-                  "2d/3d graphics",
-                  "windowing systems",
-                  "testing/ci",
-                  "gpu"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2017,
-                  2016,
-                  2015,
-                  2014,
-                  2013,
-                  2011
-            ],
-            "project": [
-                  0,
-                  0,
-                  4,
-                  0,
-                  3,
-                  4,
-                  5,
-                  2,
-                  4,
-                  0,
-                  2,
-                  1
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4524333319323648/",
-            "name": "Xapian Search Engine Library",
-            "tech": [
-                  "c++",
-                  "unicode",
-                  "swig",
-                  "linux",
-                  "golang"
-            ],
-            "cat": "Data and Databases",
-            "top": [
-                  "search",
-                  "information retrieval",
-                  "machine learning",
-                  "linguistics",
-                  "indexing"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2016,
-                  2014,
-                  2012,
-                  2011
-            ],
-            "project": [
-                  0,
-                  0,
-                  4,
-                  4,
-                  0,
-                  3,
-                  0,
-                  5,
-                  3,
-                  2,
-                  3,
-                  2
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5153224375402496/",
-            "name": "XMPP Standards Foundation",
-            "tech": [
-                  "java",
-                  "xmpp",
-                  "vala",
-                  "webrtc",
-                  "lua"
-            ],
-            "cat": "Social / Communications",
-            "top": [
-                  "instant messaging",
-                  "realtime communication",
-                  "voip"
-            ],
-            "year": [
-                  2020,
-                  2017,
-                  2015,
-                  2012,
-                  2011,
-                  2010
-            ],
-            "project": [
-                  0,
-                  4,
-                  4,
-                  7,
-                  0,
-                  0,
-                  6,
-                  0,
-                  2,
-                  0,
-                  0,
-                  2
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6726059115937792/",
-            "name": "XWiki",
-            "tech": [
-                  "java",
-                  "javascript",
-                  "html5",
-                  "css",
-                  "velocity"
-            ],
-            "cat": "Web",
-            "top": [
-                  "web development",
-                  "wiki",
-                  "platform",
-                  "web applications",
-                  "structured data"
-            ],
-            "year": [
-                  2020,
-                  2019,
-                  2018,
-                  2017,
-                  2016,
-                  2012,
-                  2011,
-                  2009
-            ],
-            "project": [
-                  4,
-                  0,
-                  3,
-                  3,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  3,
-                  3,
-                  1
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5924162381545472/",
-            "name": "Zulip",
-            "tech": [
-                  "python",
-                  "react native",
-                  "django",
-                  "typescript",
-                  "electron"
-            ],
-            "cat": "Social / Communications",
-            "top": [
-                  "bots",
-                  "mobile",
-                  "chat",
-                  "great developer tooling",
-                  "visual design"
-            ],
-            "year": [
-                  2020,
-                  2018,
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  10,
-                  10,
-                  0,
-                  18
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6331236958601216/",
-            "name": "52\u00b0North Initiative for Geospatial Open Source Software GmbH",
-            "tech": [
-                  "javascript",
-                  "android",
-                  "web",
-                  "java"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "ogc",
-                  "web processing",
-                  "sensorweb",
-                  "floating car data",
-                  "earth observation"
-            ],
-            "year": [
-                  2019,
-                  2017,
-                  2016,
-                  2015,
-                  2014,
-                  2013,
-                  2012
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  4,
-                  4,
-                  4,
-                  6,
-                  3,
-                  1,
-                  0,
-                  2,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5844178540429312/",
-            "name": "aimacode",
-            "tech": [
-                  "python",
-                  "python 3",
-                  "java",
-                  "javascript",
-                  "machine learning"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "machine learning",
-                  "artificial intelligence",
-                  " education",
-                  "open education"
-            ],
-            "year": [
-                  2019,
-                  2018,
-                  2017,
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  4,
-                  5,
-                  4,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/4551437139312640/",
-            "name": "AOSSIE - Australian Open Source Software Innovation and Education",
-            "tech": [
-                  "scala",
-                  "javascript",
-                  "isabelle proof assistant",
-                  "android",
-                  "ios"
-            ],
-            "cat": "End User Applications",
-            "top": [
-                  "electronic voting",
-                  "natural language processing",
-                  "environment",
-                  "machine learning",
-                  "philosophy"
-            ],
-            "year": [
-                  2019,
-                  2018,
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  13,
-                  13,
-                  18,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6340359469137920/",
-            "name": "API Client Tools at Google",
-            "tech": [
-                  "openapi",
-                  "grpc",
-                  "protocol buffers",
-                  "rpc",
-                  "rest"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "apis",
-                  "automation",
-                  "code generation",
-                  "api description"
-            ],
-            "year": [
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5485316792647680/",
-            "name": "appleseedhq",
-            "tech": [
-                  "c++11",
-                  "python",
-                  "opengl"
-            ],
-            "cat": "Graphics / Video / Audio / Virtual Reality",
-            "top": [
-                  "computer graphics",
-                  "image synthesis",
-                  "rendering",
-                  "animation",
-                  "simulation"
-            ],
-            "year": [
-                  2019,
-                  2018,
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  3,
-                  2,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6052415684476928/",
-            "name": "Ardupilot.org",
-            "tech": [
-                  "drones",
-                  "python",
-                  "linux",
-                  "robotics",
-                  "c/c++"
-            ],
-            "cat": "Other",
-            "top": [
-                  "vison",
-                  "robotics",
-                  "embedded systems",
-                  "real-time os",
-                  "drones"
-            ],
-            "year": [
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  5,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5906507105828864/",
-            "name": "Bazel",
-            "tech": [
-                  "windows",
-                  "c/c++",
-                  "java",
-                  "bazel"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "build tools",
-                  "developer tools"
-            ],
-            "year": [
-                  2019,
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5781930639884288/",
-            "name": "Berkman Klein Center for Internet and Society",
-            "tech": [
-                  "ruby on rails",
-                  "meteor.js",
-                  "elasticsearch",
-                  "python",
-                  "java"
-            ],
-            "cat": "Other",
-            "top": [
-                  "web",
-                  "research",
-                  "education",
-                  "internet freedom",
-                  "internet censorship"
-            ],
-            "year": [
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/4661625682919424/",
-            "name": "Biomedical Informatics, Emory University",
-            "tech": [
-                  "python",
-                  "java",
-                  "deep learning",
-                  "medical imaging",
-                  "tensorflow"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "data integration",
-                  "distributed systems",
-                  "cloud",
-                  "precision medicine",
-                  "science and medicine"
-            ],
-            "year": [
-                  2019,
-                  2016,
-                  2015,
-                  2014
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  4,
-                  4,
-                  5,
-                  0,
-                  0,
-                  4,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5526850200141824/",
-            "name": "Buildroot",
-            "tech": [
-                  "gnu make",
-                  "kconfig",
-                  "python",
-                  "shell"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "embedded systems",
-                  "linux",
-                  "build tools",
-                  "compilation"
-            ],
-            "year": [
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5152322794029056/",
-            "name": "Canadian Center for Computational Genomics",
-            "tech": [
-                  "python",
-                  "r-project",
-                  "javascript",
-                  "react",
-                  "nodejs"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "bioinformatics",
-                  " science",
-                  " visualization",
-                  " statistics",
-                  " web"
-            ],
-            "year": [
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  4,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6278222700871680/",
-            "name": "cBioPortal for Cancer Genomics",
-            "tech": [
-                  "java",
-                  "javascript",
-                  "reactjs",
-                  "database",
-                  "web apps"
-            ],
-            "cat": "Data and Databases",
-            "top": [
-                  "genomics",
-                  "bioinformatics",
-                  "big data",
-                  "data visualization",
-                  "cancer research"
-            ],
-            "year": [
-                  2019,
-                  2017,
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  5,
-                  6,
-                  0,
-                  6,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6344880593305600/",
-            "name": "CBMI@UTHSC",
-            "tech": [
-                  "reactjs",
-                  "python",
-                  "flask",
-                  "javascript",
-                  "tensorflow"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "machine learning",
-                  "deep learning",
-                  "sepsis prediction",
-                  "sepsis detection",
-                  " web applications"
-            ],
-            "year": [
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5907529257713664/",
-            "name": "Center for Research in Open Source Software at UC Santa Cruz",
-            "tech": [
-                  "python",
-                  "javascript",
-                  "c/c++",
-                  "verilog"
-            ],
-            "cat": "Other",
-            "top": [
-                  "cloud databases",
-                  "reproducibility",
-                  "ceph",
-                  "architecture",
-                  "generative text"
-            ],
-            "year": [
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  4,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/4870847817318400/",
-            "name": "CGAL project",
-            "tech": [
-                  "c++",
-                  "git",
-                  "swig",
-                  "python"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "computational geometry",
-                  "geometry processing",
-                  "mesh processing",
-                  "arrangement",
-                  "point set processing"
-            ],
-            "year": [
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  9,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5344579304292352/",
-            "name": "CLiPS, University of Antwerp",
-            "tech": [
-                  "python",
-                  "javascript",
-                  "mongodb"
-            ],
-            "cat": "Data and Databases",
-            "top": [
-                  "natural language processing",
-                  "machine learning",
-                  "artificial intelligence",
-                  "text analytics",
-                  "text generation"
-            ],
-            "year": [
-                  2019,
-                  2018,
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  4,
-                  4,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5097595045675008/",
-            "name": "coala",
-            "tech": [
-                  "python 3",
-                  "java",
-                  "angularjs",
-                  "haskell",
-                  "docker"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "code analysis",
-                  " chatops",
-                  " devops"
-            ],
-            "year": [
-                  2019,
-                  2018,
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  9,
-                  14,
-                  10,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6093511005306880/",
-            "name": "Computational Biology @ University of Nebraska-Lincoln",
-            "tech": [
-                  "javascript",
-                  "react",
-                  "postgresql",
-                  "webgl"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "web application",
-                  "bioinformatics",
-                  "computational biology",
-                  "data science",
-                  "network biology"
-            ],
-            "year": [
-                  2019,
-                  2018,
-                  2017,
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  5,
-                  4,
-                  4,
-                  5,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6267159469096960/",
-            "name": "CRIU (Checkpoint/Restore in User-space)",
-            "tech": [
-                  "docker",
-                  "linux",
-                  "containers",
-                  "kernel"
-            ],
-            "cat": "Operating Systems",
-            "top": [
-                  "cloud",
-                  "save/restore",
-                  "load-balancing",
-                  "zero-downtime",
-                  "migration"
-            ],
-            "year": [
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6223494952517632/",
-            "name": "D Programming Language",
-            "tech": [
-                  "dlang",
-                  "linux",
-                  "windows",
-                  "osx",
-                  "bsd"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "programming languages",
-                  "object-oriented programming",
-                  "functional programming",
-                  "web programming",
-                  "system programming"
-            ],
-            "year": [
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  5,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5926253033422848/",
-            "name": "Developers Italia",
-            "tech": [
-                  "python",
-                  "go",
-                  "scala",
-                  "node.js",
-                  "html/css/js"
-            ],
-            "cat": "Other",
-            "top": [
-                  "open government",
-                  "public code",
-                  " open source",
-                  " web applications",
-                  "open data"
-            ],
-            "year": [
-                  2019,
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  3,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6180395375132672/",
-            "name": "Digital Impact Alliance",
-            "tech": [
-                  "android",
-                  "java",
-                  "php",
-                  "python",
-                  "javascript"
-            ],
-            "cat": "Other",
-            "top": [
-                  "end user application",
-                  "humanitarian",
-                  "international",
-                  "social good",
-                  "charity"
-            ],
-            "year": [
-                  2019,
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  3,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6268499498893312/",
-            "name": "Earth Science Information Partners",
-            "tech": [
-                  "python",
-                  "kubernetes",
-                  "jupyter",
-                  "deep learning",
-                  "gdal"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "earth observation",
-                  "cloud databases",
-                  " data visualisation",
-                  "semantic web",
-                  "data-science"
-            ],
-            "year": [
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5379070022385664/",
-            "name": "FOSDEM",
-            "tech": [
-                  "javascript",
-                  "grafana",
-                  "voctomix",
-                  "influxdb",
-                  "ruby on rails"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "conference",
-                  "web development",
-                  "rails application",
-                  "video processing"
-            ],
-            "year": [
-                  2019,
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  0,
-                  2,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5483378286002176/",
-            "name": "FOSSASIA",
-            "tech": [
-                  "javascript",
-                  "python",
-                  "java",
-                  "reactjs",
-                  "c"
-            ],
-            "cat": "Other",
-            "top": [
-                  "artificial intelligence",
-                  "event management",
-                  "open science",
-                  "voice assistants",
-                  "search"
-            ],
-            "year": [
-                  2019,
-                  2018,
-                  2017,
-                  2016,
-                  2015,
-                  2014,
-                  2012,
-                  2011
-            ],
-            "project": [
-                  0,
-                  0,
-                  3,
-                  6,
-                  0,
-                  9,
-                  17,
-                  18,
-                  51,
-                  32,
-                  14,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/4832912116023296/",
-            "name": "FOSSology Project",
-            "tech": [
-                  "postgresql",
-                  "php",
-                  "c/c++",
-                  "jquery",
-                  "bash"
-            ],
-            "cat": "Other",
-            "top": [
-                  "compliance",
-                  "license-scan",
-                  "oss licensing",
-                  "spdx",
-                  "oss compliance"
-            ],
-            "year": [
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5090343328940032/",
-            "name": "FrameNet Brasil at the Federal University of Juiz de Fora",
-            "tech": [
-                  "php",
-                  "mysql",
-                  "javascript",
-                  "python"
-            ],
-            "cat": "Data and Databases",
-            "top": [
-                  "natural language processing",
-                  "multimodality",
-                  "natural language understanding",
-                  "image processing",
-                  "machine translation"
-            ],
-            "year": [
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6504969929228288/",
-            "name": "FreeBSD",
-            "tech": [
-                  "c/c++",
-                  "llvm",
-                  "shell script",
-                  "assembly",
-                  "make"
-            ],
-            "cat": "Operating Systems",
-            "top": [
-                  "virtualization",
-                  " kernel",
-                  "cloud",
-                  " embedded systems",
-                  "security"
-            ],
-            "year": [
-                  2019,
-                  2018,
-                  2017,
-                  2016,
-                  2015,
-                  2014,
-                  2013,
-                  2012,
-                  2011
-            ],
-            "project": [
-                  0,
-                  0,
-                  13,
-                  11,
-                  10,
-                  14,
-                  14,
-                  12,
-                  5,
-                  8,
-                  6,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6609278192844800/",
-            "name": "freifunk",
-            "tech": [
-                  "c",
-                  "python",
-                  "ruby",
-                  "openwrt",
-                  "html/css/js"
-            ],
-            "cat": "Social / Communications",
-            "top": [
-                  "network",
-                  "embedded systems",
-                  "web apps",
-                  "wireless communications",
-                  "software defined networking"
-            ],
-            "year": [
-                  2019,
-                  2018,
-                  2012,
-                  2011
-            ],
-            "project": [
-                  0,
-                  0,
-                  9,
-                  12,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  12,
-                  10,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/4535509118877696/",
-            "name": "Genes, Genomes and Variation",
-            "tech": [
-                  "perl",
-                  "mysql",
-                  "javascript",
-                  "python",
-                  "rest"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "genomics",
-                  "data analysis",
-                  "databases",
-                  " scientific visualization"
-            ],
-            "year": [
-                  2019,
-                  2018,
-                  2017,
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  5,
-                  2,
-                  3,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5661409025720320/",
-            "name": "GENIVI Alliance",
-            "tech": [
-                  "yocto",
-                  "embedded",
-                  "automotive",
-                  "some/ip"
-            ],
-            "cat": "Other",
-            "top": [
-                  "automotive",
-                  "graphics",
-                  "communication",
-                  "bigdata",
-                  " embedded systems"
-            ],
-            "year": [
-                  2019,
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  2,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/4808868352229376/",
-            "name": "GNU Compiler Collection",
-            "tech": [
-                  "c/c++",
-                  "gnu autotools"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "compilers",
-                  "toolchain",
-                  "openmp"
-            ],
-            "year": [
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  6,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5170270925488128/",
-            "name": "GNU Mailman",
-            "tech": [
-                  "python 3",
-                  "email",
-                  "rest",
-                  "django"
-            ],
-            "cat": "End User Applications",
-            "top": [
-                  "email"
-            ],
-            "year": [
-                  2019,
-                  2016,
-                  2015
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  3,
-                  0,
-                  0,
-                  1,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5844947004030976/",
-            "name": "gprMax",
-            "tech": [
-                  "python",
-                  "cuda",
-                  "openmp",
-                  "cython",
-                  "mpi"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "engineering",
-                  "geophysics",
-                  "science",
-                  "electromagnetics",
-                  "ground penetrating radar"
-            ],
-            "year": [
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6049761981890560/",
-            "name": "Haskell.Org",
-            "tech": [
-                  "haskell",
-                  "ghc",
-                  "servant",
-                  "codeworld",
-                  "cabal"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "haskell",
-                  "functional programming",
-                  "education",
-                  "build tools",
-                  "compilers"
-            ],
-            "year": [
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  15,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/4934728610742272/",
-            "name": "Institut f\u00fcr Angewandte Informatik (InfAI) e.V.",
-            "tech": [
-                  "java",
-                  "javascript",
-                  "a-frame",
-                  "neo4j",
-                  "htc vive"
-            ],
-            "cat": "Graphics / Video / Audio / Virtual Reality",
-            "top": [
-                  "virtual reality",
-                  "software quality",
-                  "visualization",
-                  "software analytics",
-                  " web"
-            ],
-            "year": [
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6502123104108544/",
-            "name": "InterMine",
-            "tech": [
-                  "java",
-                  "python",
-                  "javascript",
-                  "clojure",
-                  "r"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "bioinformatics",
-                  " web",
-                  " open science",
-                  " biology",
-                  " data visualisation"
-            ],
-            "year": [
-                  2019,
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  6,
-                  6,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6473524057735168/",
-            "name": "Internet Systems Consortium",
-            "tech": [
-                  "c/c++",
-                  "c99",
-                  "mysql",
-                  "python",
-                  "javascript"
-            ],
-            "cat": "Other",
-            "top": [
-                  "internet",
-                  "networking",
-                  "dhcp",
-                  "dns",
-                  "infrastructure"
-            ],
-            "year": [
-                  2019,
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  1,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5195087733063680/",
-            "name": "JabRef",
-            "tech": [
-                  "java",
-                  "javafx",
-                  "latex"
-            ],
-            "cat": "End User Applications",
-            "top": [
-                  "academia",
-                  "reference manager",
-                  "bibtex",
-                  "pdf"
-            ],
-            "year": [
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6743345328553984/",
-            "name": "Joomla",
-            "tech": [
-                  "php",
-                  "javascript",
-                  "mysql",
-                  "html/css",
-                  "cms"
-            ],
-            "cat": "Web",
-            "top": [
-                  "web",
-                  "web development",
-                  "web application",
-                  "programming languages",
-                  "cms"
-            ],
-            "year": [
-                  2019,
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  8,
-                  0,
-                  3,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5987024522182656/",
-            "name": "JSK Robotics Laboratory / The University of Tokyo",
-            "tech": [
-                  "ros",
-                  "lisp"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "robotics",
-                  "ros"
-            ],
-            "year": [
-                  2019,
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6612711935311872/",
-            "name": "KNIME",
-            "tech": [
-                  "javascript",
-                  "java",
-                  "tensorflow"
-            ],
-            "cat": "Data and Databases",
-            "top": [
-                  "data analytics",
-                  "data science",
-                  "machine learning",
-                  "deep learning",
-                  "image processing"
-            ],
-            "year": [
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/4556574457069568/",
-            "name": "Libvirt",
-            "tech": [
-                  "virtualization",
-                  "kvm",
-                  "xen",
-                  "c",
-                  "python"
-            ],
-            "cat": "Cloud",
-            "top": [
-                  "virtualization",
-                  "virtual machine",
-                  "libraries",
-                  "cloud"
-            ],
-            "year": [
-                  2019,
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  4,
-                  0,
-                  0,
-                  3,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5682474363912192/",
-            "name": "LLVM Compiler Infrastructure",
-            "tech": [
-                  "llvm",
-                  "clang"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "programming languages and development tools",
-                  "compiler",
-                  "code analysis"
-            ],
-            "year": [
-                  2019,
-                  2018,
-                  2017,
-                  2015,
-                  2014,
-                  2013,
-                  2010,
-                  2009
-            ],
-            "project": [
-                  5,
-                  5,
-                  0,
-                  0,
-                  4,
-                  4,
-                  3,
-                  0,
-                  8,
-                  8,
-                  8,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5012931375267840/",
-            "name": "LuaRocks",
-            "tech": [
-                  "lua"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "programming languages",
-                  "package managers",
-                  "games"
-            ],
-            "year": [
-                  2019,
-                  2018,
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  2,
-                  2,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/4888795948777472/",
-            "name": "Matrix.org",
-            "tech": [
-                  "python",
-                  "javascript",
-                  "nodejs",
-                  "postgresql",
-                  "go"
-            ],
-            "cat": "Social / Communications",
-            "top": [
-                  "decentralisation",
-                  "realtime communications",
-                  "federated",
-                  "interoperability"
-            ],
-            "year": [
-                  2019,
-                  2018,
-                  2017,
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  3,
-                  2,
-                  4,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6496732601384960/",
-            "name": "MBDyn - Multibody Dynamics",
-            "tech": [
-                  "python",
-                  "c++",
-                  "scripting"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "mechanical engineering",
-                  "aeronautics",
-                  "multibody dynamics",
-                  "aerodynamics",
-                  "linear algebra"
-            ],
-            "year": [
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/4667145252765696/",
-            "name": "MetaBrainz Foundation Inc",
-            "tech": [
-                  "python",
-                  "perl",
-                  "javascript",
-                  "postgres",
-                  "react"
-            ],
-            "cat": "Data and Databases",
-            "top": [
-                  "music",
-                  "books",
-                  "open data",
-                  "metadata",
-                  "community"
-            ],
-            "year": [
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  6,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5681434444955648/",
-            "name": "Moodle",
-            "tech": [
-                  "php",
-                  "javascript",
-                  "sql",
-                  "angular",
-                  "ionic"
-            ],
-            "cat": "Social / Communications",
-            "top": [
-                  " education",
-                  " web applications",
-                  "e-learning",
-                  "school system",
-                  "learning management"
-            ],
-            "year": [
-                  2019,
-                  2018,
-                  2017,
-                  2016,
-                  2015,
-                  2014,
-                  2013,
-                  2012,
-                  2011,
-                  2009
-            ],
-            "project": [
-                  5,
-                  0,
-                  3,
-                  4,
-                  6,
-                  2,
-                  2,
-                  4,
-                  1,
-                  0,
-                  2,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5873958367264768/",
-            "name": "Named Data Networking Project",
-            "tech": [
-                  "java",
-                  "android",
-                  "javascript",
-                  "c++14",
-                  "c#"
-            ],
-            "cat": "Web",
-            "top": [
-                  "networking",
-                  "informationc centric networking",
-                  "ipfs"
-            ],
-            "year": [
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6409236987248640/",
-            "name": "Netfilter project",
-            "tech": [
-                  "c",
-                  "linux kernel"
-            ],
-            "cat": "Operating Systems",
-            "top": [
-                  "network security",
-                  "software defined networking",
-                  "network monitoring"
-            ],
-            "year": [
-                  2019,
-                  2018,
-                  2017,
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  2,
-                  3,
-                  3,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5152196847468544/",
-            "name": "Open Astronomy",
-            "tech": [
-                  "python",
-                  "julia",
-                  "c++",
-                  "numba"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "visualisation",
-                  "astronomy",
-                  "solar physics",
-                  "high energy astrophysics",
-                  "orbital mechanics"
-            ],
-            "year": [
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  9,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5294944380518400/",
-            "name": "Open Bioinformatics Foundation",
-            "tech": [
-                  "python",
-                  "perl",
-                  "java",
-                  "javascript",
-                  "biojs"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "computational biology",
-                  "bioinformatics"
-            ],
-            "year": [
-                  2019,
-                  2018,
-                  2017,
-                  2016,
-                  2014,
-                  2012,
-                  2011,
-                  2010
-            ],
-            "project": [
-                  0,
-                  5,
-                  6,
-                  5,
-                  0,
-                  6,
-                  0,
-                  7,
-                  7,
-                  5,
-                  5,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5559834475233280/",
-            "name": "Open Data Kit",
-            "tech": [
-                  "android",
-                  "java"
-            ],
-            "cat": "End User Applications",
-            "top": [
-                  "mobile",
-                  " global development",
-                  " global health",
-                  " social good"
-            ],
-            "year": [
-                  2019,
-                  2018,
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  2,
-                  2,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6491213031538688/",
-            "name": "Open Technologies Aliance - GFOSS",
-            "tech": [
-                  "python",
-                  "javascript",
-                  "gtk",
-                  "qt",
-                  "arduino"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "robotics",
-                  "programming languages",
-                  "open education",
-                  "c- c+",
-                  "java"
-            ],
-            "year": [
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  13,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6725431019962368/",
-            "name": "Pharo Consortium",
-            "tech": [
-                  "pharo",
-                  "squeak",
-                  "smalltalk",
-                  "ide",
-                  "os"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "web development",
-                  "data science",
-                  "nlp",
-                  "material design",
-                  "cli"
-            ],
-            "year": [
-                  2019,
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  5,
-                  0,
-                  7,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5607768440963072/",
-            "name": "phpMyAdmin",
-            "tech": [
-                  "php",
-                  "mysql",
-                  "bootstrap",
-                  "javascript",
-                  "cakephp"
-            ],
-            "cat": "Data and Databases",
-            "top": [
-                  "mysql",
-                  "developer",
-                  "administrator",
-                  "database",
-                  "web applications"
-            ],
-            "year": [
-                  2019,
-                  2018,
-                  2017,
-                  2015,
-                  2014,
-                  2013,
-                  2012,
-                  2011,
-                  2010
-            ],
-            "project": [
-                  0,
-                  6,
-                  7,
-                  5,
-                  6,
-                  6,
-                  4,
-                  0,
-                  3,
-                  4,
-                  2,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5716618817044480/",
-            "name": "Project PANOPTES",
-            "tech": [
-                  "python 3",
-                  "arduino",
-                  "cloud"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "astronomy",
-                  "robotics",
-                  "exoplanet",
-                  "image processing"
-            ],
-            "year": [
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5206886662537216/",
-            "name": "Public Lab",
-            "tech": [
-                  "ruby on rails",
-                  "javascript",
-                  "node.js",
-                  "raspberry pi"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "science",
-                  "environment",
-                  "collaboration",
-                  "community",
-                  "hardware"
-            ],
-            "year": [
-                  2019,
-                  2018,
-                  2017,
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  5,
-                  5,
-                  9,
-                  12,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5218980686462976/",
-            "name": "R project for statistical computing",
-            "tech": [
-                  "r-project",
-                  "c",
-                  "c++",
-                  "fortran",
-                  "javascript"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "data science",
-                  "visualization",
-                  "statistics",
-                  "graphics",
-                  "machine learning"
-            ],
-            "year": [
-                  2019,
-                  2018,
-                  2017,
-                  2016,
-                  2012
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  16,
-                  0,
-                  0,
-                  0,
-                  22,
-                  33,
-                  24,
-                  30,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5033715393101824/",
-            "name": "Read the Docs",
-            "tech": [
-                  "python",
-                  "django",
-                  "documentation",
-                  "sphinx"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "documentation",
-                  "web"
-            ],
-            "year": [
-                  2019,
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  2,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6207728010133504/",
-            "name": "Ruby Science Foundation",
-            "tech": [
-                  "ruby",
-                  "c/c++",
-                  "cuda",
-                  "ai",
-                  "machine learning"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "scientific computing",
-                  " scientific visualization",
-                  "data-science",
-                  "hpc",
-                  "linear algebra"
-            ],
-            "year": [
-                  2019,
-                  2018,
-                  2017,
-                  2016,
-                  2015,
-                  2013
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  4,
-                  0,
-                  5,
-                  4,
-                  3,
-                  4,
-                  2,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5996747724161024/",
-            "name": "Salesforce",
-            "tech": [
-                  "scala",
-                  "apache spark",
-                  "javascript",
-                  "nodejs",
-                  "react"
-            ],
-            "cat": "Cloud",
-            "top": [
-                  "machine learning",
-                  "natural language processing",
-                  " web applications",
-                  "user interface",
-                  "cli"
-            ],
-            "year": [
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/4922378566500352/",
-            "name": "SCoRe Lab (Sustainable Computing Research Lab)",
-            "tech": [
-                  "python",
-                  "nodejs",
-                  "android",
-                  "golang"
-            ],
-            "cat": "Security",
-            "top": [
-                  "information security",
-                  "mobile",
-                  "cloud",
-                  "web development",
-                  "machine learning"
-            ],
-            "year": [
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  27,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5700571963588608/",
-            "name": "shogun.ml",
-            "tech": [
-                  "c++11",
-                  "c++17",
-                  "python",
-                  "swig",
-                  "cmake"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "machine learning",
-                  "scientific computing",
-                  "software engineering",
-                  "user experience",
-                  "data science"
-            ],
-            "year": [
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5660544999096320/",
-            "name": "Software and Computational Systems Lab at LMU Munich",
-            "tech": [
-                  "python",
-                  "java",
-                  "javascript"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "software analysis",
-                  "benchmarking",
-                  "result presentation",
-                  "smt solver",
-                  "software verification"
-            ],
-            "year": [
-                  2019,
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  2,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5852998071222272/",
-            "name": "Software Heritage",
-            "tech": [
-                  "python",
-                  "javascript",
-                  "postgres",
-                  "django",
-                  "git"
-            ],
-            "cat": "Data and Databases",
-            "top": [
-                  "digital preservation",
-                  "source code archive",
-                  "free and open source software",
-                  "big data",
-                  "big code"
-            ],
-            "year": [
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6051311592669184/",
-            "name": "SPDX (Software Product Data Exchange)",
-            "tech": [
-                  "python",
-                  "java",
-                  "golang",
-                  "xml"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "open source",
-                  "compliance",
-                  "licensing"
-            ],
-            "year": [
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  8,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6614261546090496/",
-            "name": "The Center for Connected Learning and Computer-Based Modeling",
-            "tech": [
-                  "javascript",
-                  "scala"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  " education",
-                  "simulation",
-                  "research",
-                  "programming languages"
-            ],
-            "year": [
-                  2019,
-                  2018,
-                  2017,
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  1,
-                  2,
-                  1,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/4793126693109760/",
-            "name": "The Eclipse Foundation",
-            "tech": [
-                  "java",
-                  "jakarta",
-                  "javascript",
-                  "openj9"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "ide",
-                  "cloud",
-                  "iot"
-            ],
-            "year": [
-                  2019,
-                  2018,
-                  2017,
-                  2015,
-                  2014,
-                  2013,
-                  2012,
-                  2011
-            ],
-            "project": [
-                  0,
-                  0,
-                  16,
-                  11,
-                  11,
-                  16,
-                  15,
-                  0,
-                  10,
-                  7,
-                  10,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6559697677582336/",
-            "name": "The Perl Foundation",
-            "tech": [
-                  "c",
-                  "perl",
-                  "regular expressions",
-                  "perl6",
-                  "perl5"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "web services",
-                  "natural language understanding",
-                  "functional programming",
-                  "concurrency",
-                  "programming languages and development tools"
-            ],
-            "year": [
-                  2019,
-                  2014,
-                  2011,
-                  2010,
-                  2009
-            ],
-            "project": [
-                  8,
-                  8,
-                  6,
-                  0,
-                  0,
-                  5,
-                  0,
-                  0,
-                  0,
-                  0,
-                  4,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6187982082539520/",
-            "name": "The Postgres Operator",
-            "tech": [
-                  "postgresql",
-                  "kubernetes",
-                  "golang",
-                  "operator",
-                  "patroni"
-            ],
-            "cat": "Data and Databases",
-            "top": [
-                  "cloud",
-                  "cloud native",
-                  "databases",
-                  "database services",
-                  "cloud databases"
-            ],
-            "year": [
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5422734538964992/",
-            "name": "The Processing Foundation",
-            "tech": [
-                  "java",
-                  "javascript",
-                  "python",
-                  "android",
-                  "opengl"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "creative coding",
-                  " graphics",
-                  " web",
-                  " education",
-                  " design"
-            ],
-            "year": [
-                  2019,
-                  2018,
-                  2017,
-                  2015,
-                  2014
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  11,
-                  14,
-                  0,
-                  14,
-                  16,
-                  16,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5953843416793088/",
-            "name": "The Vega Project at the University of Washington",
-            "tech": [
-                  "typescript",
-                  "d3",
-                  "vega",
-                  "vega-lite",
-                  "react"
-            ],
-            "cat": "Web",
-            "top": [
-                  "visualization",
-                  "data-science"
-            ],
-            "year": [
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6213357017759744/",
-            "name": "TimVideos.us",
-            "tech": [
-                  "python",
-                  "verilog",
-                  "vhdl",
-                  "c",
-                  "fpga"
-            ],
-            "cat": "Graphics / Video / Audio / Virtual Reality",
-            "top": [
-                  "hardware",
-                  " embedded",
-                  "video",
-                  "fpga"
-            ],
-            "year": [
-                  2019,
-                  2018,
-                  2016,
-                  2014,
-                  2013
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  7,
-                  0,
-                  2,
-                  0,
-                  2,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6043030627287040/",
-            "name": "Tokio",
-            "tech": [
-                  "tokio_rs",
-                  "rust"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "rust",
-                  "networking",
-                  "windows",
-                  "concurrency"
-            ],
-            "year": [
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5098459072299008/",
-            "name": "Tungsten Fabric",
-            "tech": [
-                  "linux",
-                  "kubernetes",
-                  "python",
-                  "networking",
-                  "c/c++"
-            ],
-            "cat": "Cloud",
-            "top": [
-                  "software defined networking",
-                  "routing",
-                  "security",
-                  "multicloud"
-            ],
-            "year": [
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/4731456398557184/",
-            "name": "UCSC Xena",
-            "tech": [
-                  "javascript",
-                  "python",
-                  "clojure",
-                  "react"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "genomics",
-                  "cancer research",
-                  " scientific visualization",
-                  "bioinformatics"
-            ],
-            "year": [
-                  2019,
-                  2018,
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  1,
-                  1,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/4795917817872384/",
-            "name": "Xi Editor",
-            "tech": [
-                  "rust",
-                  "swift"
-            ],
-            "cat": "End User Applications",
-            "top": [
-                  "ide",
-                  "end user application",
-                  "text editor"
-            ],
-            "year": [
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5008573141090304/",
-            "name": "XMPP Standards Foundation (XSF)",
-            "tech": [
-                  "asynchronous i/o",
-                  "lua",
-                  "xmpp",
-                  "java",
-                  "python 3"
-            ],
-            "cat": "Social / Communications",
-            "top": [
-                  "instant messaging",
-                  "realtime communications",
-                  "machine-to-machine",
-                  "internet of things",
-                  "xmpp"
-            ],
-            "year": [
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6320987639906304/",
-            "name": "xpra",
-            "tech": [
-                  "python",
-                  "javascript",
-                  "c"
-            ],
-            "cat": "Graphics / Video / Audio / Virtual Reality",
-            "top": [
-                  "remote-access",
-                  "video",
-                  "desktop",
-                  "seamless"
-            ],
-            "year": [
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/4652389204754432/",
-            "name": "Zulip Open Source Project",
-            "tech": [
-                  "python",
-                  "react native",
-                  "django",
-                  "javascript",
-                  "electron"
-            ],
-            "cat": "Social / Communications",
-            "top": [
-                  "bots",
-                  "mobile",
-                  "visual design",
-                  "chat",
-                  "great developer tooling"
-            ],
-            "year": [
-                  2019,
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  0,
-                  0,
-                  17,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5486812028469248/",
-            "name": "ZynAddSubFX",
-            "tech": [
-                  "c/c++",
-                  "ruby",
-                  "midi",
-                  "open-sound-control",
-                  "opengl"
-            ],
-            "cat": "Graphics / Video / Audio / Virtual Reality",
-            "top": [
-                  "audio",
-                  "digital signal processing",
-                  " visualization",
-                  "music",
-                  "user experience"
-            ],
-            "year": [
-                  2019
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5685665089978368/",
-            "name": "3DTK",
-            "tech": [
-                  "c/c++",
-                  "cmake",
-                  "opencv",
-                  "ros",
-                  "boost"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  " 3d",
-                  "point clouds",
-                  "slam",
-                  "robotics",
-                  "mapping"
-            ],
-            "year": [
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5067792839606272/",
-            "name": "52\u00b0 North Initiative for Geospatial Open Source Software GmbH",
-            "tech": [
-                  "javascript",
-                  "java",
-                  "spring",
-                  "r",
-                  "big data"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "geoinformatics",
-                  "geoprocessing",
-                  "remote sensing",
-                  "geostatistics",
-                  "sensor web"
-            ],
-            "year": [
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5175246747336704/",
-            "name": "Apache Software Foundation",
-            "tech": [
-                  "c",
-                  "java",
-                  "erlang"
-            ],
-            "cat": "Other",
-            "top": [
-                  "other",
-                  "cloud",
-                  "libraries",
-                  "big data"
-            ],
-            "year": [
-                  2018,
-                  2017,
-                  2016,
-                  2015,
-                  2014,
-                  2013,
-                  2012,
-                  2011,
-                  2010
-            ],
-            "project": [
-                  0,
-                  39,
-                  35,
-                  38,
-                  44,
-                  33,
-                  47,
-                  35,
-                  23,
-                  23,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5706275094528000/",
-            "name": "Apertus Association",
-            "tech": [
-                  "fpga",
-                  "embedded",
-                  "linux",
-                  "c/c++",
-                  "vhdl"
-            ],
-            "cat": "Graphics / Video / Audio / Virtual Reality",
-            "top": [
-                  "vision",
-                  "camera",
-                  "cinematography",
-                  "digital imaging",
-                  "photography"
-            ],
-            "year": [
-                  2018,
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  4,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5713309579870208/",
-            "name": "BeagleBoard.org Foundation",
-            "tech": [
-                  "linux",
-                  "gcc",
-                  "real-time",
-                  "physical computing",
-                  "iot"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "robotics",
-                  "ros",
-                  "audio",
-                  "iot",
-                  "interfaces"
-            ],
-            "year": [
-                  2018,
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  6,
-                  3,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5082029850886144/",
-            "name": "Beam Community",
-            "tech": [
-                  "erlang",
-                  "xmpp"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "distributed computing",
-                  "real time",
-                  "distributed databases",
-                  "iot",
-                  "instant messaging"
-            ],
-            "year": [
-                  2018,
-                  2017,
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  6,
-                  7,
-                  6,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5679790782676992/",
-            "name": "BeeWare Project",
-            "tech": [
-                  "python",
-                  "ios",
-                  "android",
-                  "javascript",
-                  "java"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "mobile",
-                  "cross desktop",
-                  "app development"
-            ],
-            "year": [
-                  2018,
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  2,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5751016104394752/",
-            "name": "Berkman Klein Center for Internet & Society at Harvard University",
-            "tech": [
-                  "ruby on rails",
-                  "meteor.js",
-                  "elasticsearch",
-                  "javascript",
-                  "elk"
-            ],
-            "cat": "Other",
-            "top": [
-                  " web",
-                  " research",
-                  "education",
-                  "internet freedom",
-                  "internet censorship"
-            ],
-            "year": [
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5136992144719872/",
-            "name": "Boost C++ Libraries",
-            "tech": [
-                  "c++11",
-                  "c++14",
-                  "c++",
-                  "c++17"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "c++ development",
-                  "c++ tools",
-                  "c++ standardization",
-                  "software engineering"
-            ],
-            "year": [
-                  2018,
-                  2017,
-                  2015,
-                  2014,
-                  2013,
-                  2011,
-                  2010
-            ],
-            "project": [
-                  0,
-                  9,
-                  9,
-                  0,
-                  7,
-                  8,
-                  7,
-                  0,
-                  4,
-                  9,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5193342920949760/",
-            "name": "Boston University / XIA",
-            "tech": [
-                  "xia",
-                  "linux kernel",
-                  "c",
-                  "advanced data structures",
-                  "ddos"
-            ],
-            "cat": "Cloud",
-            "top": [
-                  "computer networking",
-                  "future internet architecture",
-                  "research"
-            ],
-            "year": [
-                  2018,
-                  2017,
-                  2016,
-                  2015
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  2,
-                  2,
-                  4,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/6272574585569280/",
-            "name": "Center for Research In Open Source Software (CROSS) at UC Santa Cruz",
-            "tech": [
-                  "ceph",
-                  "hadoop",
-                  "c++",
-                  "javascript",
-                  "python"
-            ],
-            "cat": "Other",
-            "top": [
-                  "distributed networks",
-                  "reproducibility",
-                  "storage systems",
-                  "big data",
-                  "opendata"
-            ],
-            "year": [
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5116840829255680/",
-            "name": "CHAOSS: Community Health Analytics Open Source Software",
-            "tech": [
-                  "python 3",
-                  "javascript"
-            ],
-            "cat": "End User Applications",
-            "top": [
-                  "data visualization",
-                  "visualization",
-                  "machine learning"
-            ],
-            "year": [
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/4828166816268288/",
-            "name": "CiviCRM LLC",
-            "tech": [
-                  "php",
-                  "mysql",
-                  "angularjs",
-                  "d3.js"
-            ],
-            "cat": "End User Applications",
-            "top": [
-                  "civil society",
-                  "contacts&calendar sync"
-            ],
-            "year": [
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  4,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5114353707646976/",
-            "name": "Classical Language Toolkit",
-            "tech": [
-                  "python",
-                  "javascript"
-            ],
-            "cat": "Other",
-            "top": [
-                  "natural language processing",
-                  " web"
-            ],
-            "year": [
-                  2018,
-                  2017,
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  2,
-                  3,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/6032491081105408/",
-            "name": "Conversations.im",
-            "tech": [
-                  "java",
-                  "android",
-                  "xmpp",
-                  "gtk",
-                  "javascript"
-            ],
-            "cat": "Social / Communications",
-            "top": [
-                  "instant messaging",
-                  "mobile",
-                  "desktop",
-                  "web"
-            ],
-            "year": [
-                  2018,
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  3,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/4794601982394368/",
-            "name": "Cuneiform Digital Library Initiative",
-            "tech": [
-                  "python",
-                  "mariadb",
-                  "rdf",
-                  "php",
-                  "nltk"
-            ],
-            "cat": "Data and Databases",
-            "top": [
-                  "natural language processing",
-                  "machine translation",
-                  "information retrieval",
-                  "linguistics",
-                  "semantic web"
-            ],
-            "year": [
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/6481377977434112/",
-            "name": "Debian Project",
-            "tech": [
-                  "javascript",
-                  "ruby",
-                  "java",
-                  "python",
-                  "c/c++"
-            ],
-            "cat": "Operating Systems",
-            "top": [
-                  "operating system",
-                  "packaging",
-                  "applications",
-                  "community",
-                  "communications"
-            ],
-            "year": [
-                  2018,
-                  2016,
-                  2015,
-                  2014,
-                  2013,
-                  2011,
-                  2010
-            ],
-            "project": [
-                  0,
-                  8,
-                  7,
-                  0,
-                  15,
-                  17,
-                  15,
-                  20,
-                  0,
-                  22,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/4862665201549312/",
-            "name": "Earth Science Information Partners (ESIP)",
-            "tech": [
-                  "kubernetes",
-                  "dask",
-                  "xarray",
-                  "python",
-                  "javascript"
-            ],
-            "cat": "Data and Databases",
-            "top": [
-                  "earth data",
-                  "semantics",
-                  "discovery",
-                  "data visualization",
-                  "earth science"
-            ],
-            "year": [
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/4825444746526720/",
-            "name": "Eta",
-            "tech": [
-                  "haskell",
-                  "jvm",
-                  "java"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "functional-programming",
-                  "runtime systems",
-                  "compilers",
-                  "programming-tools"
-            ],
-            "year": [
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/6511795204259840/",
-            "name": "Free UK Genealogy",
-            "tech": [
-                  "mongodb",
-                  "ruby on rails",
-                  "mysql",
-                  "python",
-                  "css/html"
-            ],
-            "cat": "Data and Databases",
-            "top": [
-                  "ai",
-                  "machine learning",
-                  " ui/ux",
-                  " web apps",
-                  "open data"
-            ],
-            "year": [
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5472477677355008/",
-            "name": "GFOSS - Open Technologies Alliance",
-            "tech": [
-                  "python 3",
-                  "php/javascript/html",
-                  "css/html",
-                  "java",
-                  "c/c++"
-            ],
-            "cat": "Other",
-            "top": [
-                  "python",
-                  "gtk",
-                  "java jsp",
-                  "c++ tools",
-                  "javascript"
-            ],
-            "year": [
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  10,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/6595441034526720/",
-            "name": "GNU Project",
-            "tech": [
-                  "c",
-                  "lisp",
-                  "python"
-            ],
-            "cat": "Operating Systems",
-            "top": [
-                  "free software",
-                  "operating system"
-            ],
-            "year": [
-                  2018,
-                  2016,
-                  2015,
-                  2014,
-                  2013,
-                  2012,
-                  2009
-            ],
-            "project": [
-                  7,
-                  0,
-                  0,
-                  21,
-                  30,
-                  17,
-                  12,
-                  15,
-                  0,
-                  9,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/4768790235578368/",
-            "name": "gRPC",
-            "tech": [
-                  "grpc",
-                  "microservices",
-                  "distributed systems",
-                  "cloud"
-            ],
-            "cat": "Cloud",
-            "top": [
-                  "microservices",
-                  "communications",
-                  "distributed networks",
-                  "infrastructure",
-                  "middleware"
-            ],
-            "year": [
-                  2018,
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0,
-                  1,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/6603344982310912/",
-            "name": "Inria Foundation",
-            "tech": [
-                  "c/c++",
-                  "qt",
-                  "webassembly",
-                  "asm",
-                  "communication protocol"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "medical simulation",
-                  "medical research",
-                  "physics",
-                  "real-time",
-                  "scientific computing"
-            ],
-            "year": [
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/4682207855640576/",
-            "name": "Institute for Artificial Intelligence",
-            "tech": [
-                  "c++",
-                  "python",
-                  "ros",
-                  "unreal engine",
-                  "lisp"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "artificial intelligence",
-                  "robotics",
-                  "simulation",
-                  "unreal engine",
-                  "perception"
-            ],
-            "year": [
-                  2018,
-                  2017,
-                  2015,
-                  2014
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  2,
-                  0,
-                  5,
-                  6,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5956298361274368/",
-            "name": "JGraphT",
-            "tech": [
-                  "java"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "graphs",
-                  "algorithms",
-                  "data structures",
-                  "mathematics",
-                  "network analysis"
-            ],
-            "year": [
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/6348667246084096/",
-            "name": "Jitsi",
-            "tech": [
-                  "java",
-                  "javascript",
-                  "webrtc",
-                  "react",
-                  "react native"
-            ],
-            "cat": "Social / Communications",
-            "top": [
-                  "real time communications",
-                  "web",
-                  "video conferencing",
-                  "networking",
-                  "multimedia"
-            ],
-            "year": [
-                  2018,
-                  2017,
-                  2014
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  0,
-                  0,
-                  3,
-                  3,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/6484151049912320/",
-            "name": "Joomla!",
-            "tech": [
-                  "php",
-                  "javascript",
-                  "mysql",
-                  "html5/css3",
-                  "cms"
-            ],
-            "cat": "Web",
-            "top": [
-                  "web",
-                  "web development",
-                  "web applications",
-                  "cms",
-                  "object-oriented"
-            ],
-            "year": [
-                  2018,
-                  2016,
-                  2012,
-                  2009
-            ],
-            "project": [
-                  16,
-                  0,
-                  0,
-                  7,
-                  0,
-                  0,
-                  0,
-                  5,
-                  0,
-                  7,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/4898832450060288/",
-            "name": "languagetool.org",
-            "tech": [
-                  "java",
-                  "javascript",
-                  "machine learning",
-                  "ai",
-                  "tensorflow"
-            ],
-            "cat": "End User Applications",
-            "top": [
-                  "artificial intelligence",
-                  "language",
-                  "edtech",
-                  "education",
-                  "nlp"
-            ],
-            "year": [
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/6409962536304640/",
-            "name": "LEAP Encryption Access Project",
-            "tech": [
-                  "python",
-                  "twisted",
-                  "javascript",
-                  "openvpn",
-                  "gnupg"
-            ],
-            "cat": "End User Applications",
-            "top": [
-                  "e2e",
-                  "mail",
-                  "vpn",
-                  "encryption"
-            ],
-            "year": [
-                  2018,
-                  2014
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0,
-                  0,
-                  0,
-                  1,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5431834603159552/",
-            "name": "Mixxx DJ Software",
-            "tech": [
-                  "qt",
-                  "audio",
-                  "music",
-                  "real-time",
-                  "c++"
-            ],
-            "cat": "Graphics / Video / Audio / Virtual Reality",
-            "top": [
-                  "beatdetection",
-                  "metadata"
-            ],
-            "year": [
-                  2018,
-                  2017,
-                  2016,
-                  2014,
-                  2013,
-                  2012
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  4,
-                  4,
-                  2,
-                  0,
-                  2,
-                  2,
-                  2,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/6557734510002176/",
-            "name": "Mobile Robot Programming Toolkit (MRPT)",
-            "tech": [
-                  "c/c++",
-                  "cmake",
-                  "python",
-                  "webs"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "robot",
-                  "ai",
-                  "computer vision",
-                  "real-time",
-                  "slam"
-            ],
-            "year": [
-                  2018,
-                  2017,
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  4,
-                  1,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/4941292362530816/",
-            "name": "MovingBlocks",
-            "tech": [
-                  "java",
-                  "opengl",
-                  "json",
-                  "blender",
-                  "github"
-            ],
-            "cat": "End User Applications",
-            "top": [
-                  "game",
-                  "voxel",
-                  "minecraft",
-                  "sandbox",
-                  "modding"
-            ],
-            "year": [
-                  2018,
-                  2017,
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  10,
-                  9,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/6067192269373440/",
-            "name": "omegaUp.com",
-            "tech": [
-                  "php",
-                  "mysql",
-                  "python"
-            ],
-            "cat": "Web",
-            "top": [
-                  "cs education",
-                  "education",
-                  "web community"
-            ],
-            "year": [
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5395828684357632/",
-            "name": "Open Food Facts",
-            "tech": [
-                  "perl",
-                  "mongodb",
-                  "ios",
-                  "android",
-                  "machine learning"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "computer vision",
-                  "crowdsourcing",
-                  "open data",
-                  "food",
-                  "health"
-            ],
-            "year": [
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5792235979276288/",
-            "name": "Open Roberta Lab",
-            "tech": [
-                  "java",
-                  "javascript"
-            ],
-            "cat": "Web",
-            "top": [
-                  "education",
-                  "programming",
-                  "robotics"
-            ],
-            "year": [
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/4806851430449152/",
-            "name": "Open States",
-            "tech": [
-                  "python",
-                  "django",
-                  "react",
-                  "graphql",
-                  "postgresql"
-            ],
-            "cat": "Other",
-            "top": [
-                  "civic tech",
-                  "scraping",
-                  "web",
-                  "government"
-            ],
-            "year": [
-                  2018,
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5351751314046976/",
-            "name": "OpenCensus",
-            "tech": [
-                  "python",
-                  "java",
-                  "ruby",
-                  "node",
-                  "go"
-            ],
-            "cat": "Cloud",
-            "top": [
-                  "tracing",
-                  "monitoring",
-                  "c++",
-                  "php"
-            ],
-            "year": [
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/4660316541550592/",
-            "name": "OpenSIPS",
-            "tech": [
-                  "c",
-                  "python",
-                  "mysql",
-                  "scripting"
-            ],
-            "cat": "Social / Communications",
-            "top": [
-                  "voip",
-                  "telephony",
-                  "real-time-communications",
-                  "sip"
-            ],
-            "year": [
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5250379281334272/",
-            "name": "openSUSE",
-            "tech": [
-                  "ruby on rail",
-                  "perl",
-                  "ruby",
-                  "html/javascript",
-                  "c/c++"
-            ],
-            "cat": "Operating Systems",
-            "top": [
-                  " web",
-                  "qa",
-                  "packaging",
-                  " ui/ux"
-            ],
-            "year": [
-                  2018,
-                  2017,
-                  2016,
-                  2014,
-                  2013,
-                  2012
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  9,
-                  10,
-                  14,
-                  0,
-                  6,
-                  5,
-                  2,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5214740582236160/",
-            "name": "OpnTec",
-            "tech": [
-                  "python",
-                  "javascript",
-                  "emberjs",
-                  "cloud",
-                  "android"
-            ],
-            "cat": "Social / Communications",
-            "top": [
-                  "open event",
-                  "event solutions",
-                  "web"
-            ],
-            "year": [
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/6376279188176896/",
-            "name": "OW2",
-            "tech": [
-                  "java",
-                  "perl",
-                  "middleware",
-                  "bpm",
-                  "wiki"
-            ],
-            "cat": "Other",
-            "top": [
-                  "enterprise information systems",
-                  "cloud",
-                  "security",
-                  "middleware"
-            ],
-            "year": [
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/4692141242580992/",
-            "name": "P2PSP.org",
-            "tech": [
-                  "python",
-                  "javascript",
-                  "webrtc",
-                  "sockets",
-                  "c/c++"
-            ],
-            "cat": "Graphics / Video / Audio / Virtual Reality",
-            "top": [
-                  "live streaming",
-                  "real time",
-                  "distributed networks",
-                  "p2p",
-                  "video"
-            ],
-            "year": [
-                  2018,
-                  2017,
-                  2016,
-                  2015
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  2,
-                  2,
-                  1,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5208530327961600/",
-            "name": "phpBB Forum Software",
-            "tech": [
-                  "mysql",
-                  "javascript",
-                  "html5/css3",
-                  "php",
-                  "symfony"
-            ],
-            "cat": "Social / Communications",
-            "top": [
-                  "social",
-                  "communication",
-                  "collaboration",
-                  "forum",
-                  "community"
-            ],
-            "year": [
-                  2018,
-                  2017,
-                  2014,
-                  2013,
-                  2012
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  3,
-                  5,
-                  3,
-                  0,
-                  0,
-                  2,
-                  2,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5782644243562496/",
-            "name": "Plone",
-            "tech": [
-                  "python",
-                  "javascript",
-                  "html",
-                  "css",
-                  "reactjs"
-            ],
-            "cat": "Web",
-            "top": [
-                  "communications",
-                  "collaboration",
-                  "content management",
-                  "web"
-            ],
-            "year": [
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  4,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5852375185096704/",
-            "name": "PMD",
-            "tech": [
-                  "java",
-                  "xml",
-                  "javacc",
-                  "antlr",
-                  "xpath"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "code analysis",
-                  "code quality",
-                  "source code analyzer",
-                  "linter"
-            ],
-            "year": [
-                  2018,
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  1,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/6441884142534656/",
-            "name": "Pocket Science Lab",
-            "tech": [
-                  "android",
-                  "java",
-                  "firmware",
-                  "c",
-                  "cad"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "science",
-                  "education",
-                  "firmware",
-                  "school apps"
-            ],
-            "year": [
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/4933265605525504/",
-            "name": "Polly Labs",
-            "tech": [
-                  "c/c++",
-                  "llvm",
-                  "polly",
-                  "isl",
-                  "ppcg"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "compilers",
-                  "polyhedral model"
-            ],
-            "year": [
-                  2018,
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  3,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5818041149423616/",
-            "name": "Probot",
-            "tech": [
-                  "javascript",
-                  "node",
-                  "github"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "bot",
-                  "automation",
-                  "development tools"
-            ],
-            "year": [
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5331740188999680/",
-            "name": "Python HYDRA",
-            "tech": [
-                  "python",
-                  "rdf",
-                  "flask",
-                  "hydra",
-                  "json/json-ld"
-            ],
-            "cat": "Web",
-            "top": [
-                  "apis",
-                  "database",
-                  "functional-programming",
-                  "semantic web",
-                  "knowledge graph"
-            ],
-            "year": [
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/4724462213660672/",
-            "name": "Quill.org",
-            "tech": [
-                  "ruby",
-                  "rails",
-                  "react",
-                  "javascript",
-                  "postgresql"
-            ],
-            "cat": "Web",
-            "top": [
-                  "education",
-                  "edtech",
-                  "machine learning",
-                  "nlp",
-                  "web"
-            ],
-            "year": [
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5393348407853056/",
-            "name": "radare",
-            "tech": [
-                  "c",
-                  "cpp",
-                  "rust",
-                  "qt"
-            ],
-            "cat": "Security",
-            "top": [
-                  "reverse engineering"
-            ],
-            "year": [
-                  2018,
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  0,
-                  5,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5729327995944960/",
-            "name": "Rspamd",
-            "tech": [
-                  "c",
-                  "machine learning",
-                  "javascript",
-                  "lua"
-            ],
-            "cat": "Security",
-            "top": [
-                  "email",
-                  "spam filtering",
-                  "high performance computing"
-            ],
-            "year": [
-                  2018,
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5717023518621696/",
-            "name": "Ruby on Rails",
-            "tech": [
-                  "ruby",
-                  "ruby on rails",
-                  "html"
-            ],
-            "cat": "Web",
-            "top": [
-                  "web",
-                  "web development",
-                  "web applications"
-            ],
-            "year": [
-                  2018,
-                  2017,
-                  2015,
-                  2014,
-                  2013,
-                  2009
-            ],
-            "project": [
-                  4,
-                  0,
-                  0,
-                  0,
-                  5,
-                  7,
-                  6,
-                  0,
-                  2,
-                  2,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5677303661068288/",
-            "name": "Sage Mathematical Software System",
-            "tech": [
-                  "python 3",
-                  "python",
-                  "cython",
-                  "c/c++"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "mathematics",
-                  "toolbox"
-            ],
-            "year": [
-                  2018,
-                  2017,
-                  2016,
-                  2015,
-                  2014,
-                  2013,
-                  2012
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  3,
-                  3,
-                  5,
-                  5,
-                  5,
-                  5,
-                  5,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5122715136557056/",
-            "name": "Scala",
-            "tech": [
-                  "scala",
-                  "jvm",
-                  "llvm"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "compilers",
-                  "programming-tools",
-                  "functional-programming",
-                  "programming-language"
-            ],
-            "year": [
-                  2018,
-                  2017,
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  9,
-                  8,
-                  1,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/4786317862895616/",
-            "name": "Scilab",
-            "tech": [
-                  "c",
-                  "c++",
-                  "java",
-                  "scilab"
-            ],
-            "cat": "End User Applications",
-            "top": [
-                  "science",
-                  "mathematics",
-                  "numerical computation",
-                  "graphics"
-            ],
-            "year": [
-                  2018,
-                  2017,
-                  2012,
-                  2011
-            ],
-            "project": [
-                  0,
-                  0,
-                  7,
-                  10,
-                  0,
-                  0,
-                  0,
-                  0,
-                  5,
-                  4,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5132636779446272/",
-            "name": "Seastar",
-            "tech": [
-                  "cpp",
-                  "framework",
-                  "dpdk",
-                  "tcp",
-                  "linux"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "high performance",
-                  "tcp",
-                  "app development",
-                  "network",
-                  "framework"
-            ],
-            "year": [
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5667370274127872/",
-            "name": "Space @ Virginia Tech",
-            "tech": [
-                  "python",
-                  "javascript",
-                  "d3",
-                  "mysql",
-                  "mongodb"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "real time",
-                  "web",
-                  "data visualization",
-                  "data analytics"
-            ],
-            "year": [
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/6199903000723456/",
-            "name": "Stemformatics",
-            "tech": [
-                  "python",
-                  "javascript",
-                  "postgresql"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "web applications",
-                  "cloud",
-                  "bioinformatics"
-            ],
-            "year": [
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/6248264466694144/",
-            "name": "STE||AR Group",
-            "tech": [
-                  "c++",
-                  "cuda",
-                  "opencv",
-                  "python",
-                  "boost"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "hpc",
-                  "parallel algorithms",
-                  "runtime systems",
-                  "distributed datastructures",
-                  "asynchronous many task systems"
-            ],
-            "year": [
-                  2018,
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  4,
-                  4,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/6275038890164224/",
-            "name": "Stony Brook University Biomedical Informatics",
-            "tech": [
-                  "python",
-                  "matlab",
-                  "c++",
-                  "javascript"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "biomedical data science",
-                  "cancer informatics",
-                  "deep learning",
-                  "medical imaging"
-            ],
-            "year": [
-                  2018,
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  4,
-                  0,
-                  2,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5918428024012800/",
-            "name": "Streetmix",
-            "tech": [
-                  "javascript",
-                  "react",
-                  "redux",
-                  "postgresql",
-                  "mongodb"
-            ],
-            "cat": "End User Applications",
-            "top": [
-                  "smart cities",
-                  "web",
-                  "civic tech"
-            ],
-            "year": [
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5745237494333440/",
-            "name": "Sustainable Computing Research Group (SCoRe)",
-            "tech": [
-                  "android",
-                  "java",
-                  "go",
-                  "node",
-                  "pyth"
-            ],
-            "cat": "Web",
-            "top": [
-                  "iot",
-                  "web",
-                  "mobile",
-                  "machine learning",
-                  "security"
-            ],
-            "year": [
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  18,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/6321870005600256/",
-            "name": "Systers Community",
-            "tech": [
-                  "ios",
-                  "android",
-                  "python",
-                  "ruby on rails",
-                  "javascript"
-            ],
-            "cat": "Other",
-            "top": [
-                  "mobile applications",
-                  " web apps",
-                  "community"
-            ],
-            "year": [
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  11,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/6265117784145920/",
-            "name": "TEAMMATES @ National University of Singapore",
-            "tech": [
-                  "java",
-                  "appengine",
-                  "javascript"
-            ],
-            "cat": "Web",
-            "top": [
-                  "education",
-                  "teaching",
-                  "cloud",
-                  "web applications"
-            ],
-            "year": [
-                  2018,
-                  2017,
-                  2016,
-                  2015
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  6,
-                  7,
-                  8,
-                  5,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/4867664006610944/",
-            "name": "The MacPorts Project",
-            "tech": [
-                  "tcl",
-                  "html/javascript",
-                  "frontend",
-                  "vue.js",
-                  "react.js"
-            ],
-            "cat": "End User Applications",
-            "top": [
-                  "package manager",
-                  "mac os x",
-                  "macos",
-                  "command line",
-                  "build tools"
-            ],
-            "year": [
-                  2018,
-                  2017,
-                  2015,
-                  2014,
-                  2011,
-                  2010,
-                  2009
-            ],
-            "project": [
-                  2,
-                  3,
-                  3,
-                  0,
-                  0,
-                  3,
-                  2,
-                  0,
-                  2,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/6475167723159552/",
-            "name": "The Qt Project",
-            "tech": [
-                  "c++11",
-                  "cpp",
-                  "qt",
-                  "qml",
-                  "opengl"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "graphics",
-                  "gis",
-                  "maps",
-                  "declarative language"
-            ],
-            "year": [
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5651276360581120/",
-            "name": "The syslog-ng project.",
-            "tech": [
-                  "java",
-                  "c/c++",
-                  "big data",
-                  "elasticsearch",
-                  "rest"
-            ],
-            "cat": "Security",
-            "top": [
-                  "logging",
-                  "log management",
-                  "message queue",
-                  "python"
-            ],
-            "year": [
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/4645580374540288/",
-            "name": "The Vega Visualization Tools by the UW Interactive Data Lab",
-            "tech": [
-                  "javascript",
-                  "typescript",
-                  "react",
-                  "d3.js"
-            ],
-            "cat": "Data and Databases",
-            "top": [
-                  "data visualization",
-                  "visualization grammar",
-                  "data science",
-                  "declarative language",
-                  "plotting tools"
-            ],
-            "year": [
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/6308187447754752/",
-            "name": "TLA+",
-            "tech": [
-                  "java",
-                  "tla+",
-                  "eclipse",
-                  "ocaml",
-                  "smt"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "formal methods",
-                  "algorithms"
-            ],
-            "year": [
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5088548537499648/",
-            "name": "ViSP",
-            "tech": [
-                  "c/c++"
-            ],
-            "cat": "Graphics / Video / Audio / Virtual Reality",
-            "top": [
-                  "robotics",
-                  "computer vision"
-            ],
-            "year": [
-                  2018,
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  2,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/4801054029905920/",
-            "name": "vitrivr",
-            "tech": [
-                  "java",
-                  "angularjs",
-                  "spark",
-                  "grpc"
-            ],
-            "cat": "Data and Databases",
-            "top": [
-                  "retrieval",
-                  "multimedia",
-                  "video",
-                  "audio",
-                  "3d"
-            ],
-            "year": [
-                  2018,
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  0,
-                  1,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/4651790628814848/",
-            "name": "WorldBrain.io - Verifying the Internet",
-            "tech": [
-                  "react",
-                  "javascript",
-                  "browser extension",
-                  "datproject"
-            ],
-            "cat": "End User Applications",
-            "top": [
-                  "search",
-                  "fake-news",
-                  "decentralization",
-                  "misinformation",
-                  "bookmarking"
-            ],
-            "year": [
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/4893771770626048/",
-            "name": "X.org Foundation",
-            "tech": [
-                  "opengl",
-                  "vulkan",
-                  "x11",
-                  "wayland",
-                  "opencl"
-            ],
-            "cat": "Graphics / Video / Audio / Virtual Reality",
-            "top": [
-                  "graphic stack",
-                  "3d acceleration",
-                  "2d acceleration",
-                  "media acceleration",
-                  "windowing system"
-            ],
-            "year": [
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5991099608858624/",
-            "name": "XBMC Foundation",
-            "tech": [
-                  "python",
-                  "c/c++",
-                  "github",
-                  "mysql"
-            ],
-            "cat": "Graphics / Video / Audio / Virtual Reality",
-            "top": [
-                  "home theater",
-                  "audio",
-                  "video"
-            ],
-            "year": [
-                  2018,
-                  2017,
-                  2015,
-                  2012
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  4,
-                  0,
-                  0,
-                  3,
-                  0,
-                  3,
-                  2,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/6530090020110336/",
-            "name": "Xi Editor Project",
-            "tech": [
-                  "rust",
-                  "swift"
-            ],
-            "cat": "End User Applications",
-            "top": [
-                  "text editing",
-                  "ide"
-            ],
-            "year": [
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5969765231230976/",
-            "name": "xpra.org",
-            "tech": [
-                  "python",
-                  "javascript",
-                  "compression",
-                  "remote access",
-                  "cython"
-            ],
-            "cat": "End User Applications",
-            "top": [
-                  "graphics",
-                  "remote access"
-            ],
-            "year": [
-                  2018
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/6448304984424448/",
-            "name": "AboutCode",
-            "tech": [
-                  "python",
-                  "c/c++",
-                  "javascript",
-                  "shell script",
-                  "static analysis"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "free and open source software  license and origin",
-                  "package and dependencies licensing and origin",
-                  "package vulnerabilities and security",
-                  "code scan and matching",
-                  "code analysis and spdx"
-            ],
-            "year": [
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  4,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/5933754749026304/",
-            "name": "Babel",
-            "tech": [
-                  "javascript",
-                  "babel",
-                  "nodejs"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "compilers",
-                  "ast",
-                  "minifier",
-                  "tc39"
-            ],
-            "year": [
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/5825274612547584/",
-            "name": "Berkman Klein Center for Internet and Society at Harvard University",
-            "tech": [
-                  "ruby on rails",
-                  "meteor.js",
-                  "d3",
-                  "elasticsearch",
-                  "javascript"
-            ],
-            "cat": "Web",
-            "top": [
-                  "digital rights",
-                  "internet access",
-                  "security and privacy",
-                  "law",
-                  " web"
-            ],
-            "year": [
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  5,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/6571413242642432/",
-            "name": "Cadasta",
-            "tech": [
-                  "python",
-                  "django",
-                  "javasc",
-                  "javascipt"
-            ],
-            "cat": "End User Applications",
-            "top": [
-                  "web",
-                  "land rights",
-                  "mapping",
-                  "geo",
-                  "geospatial"
-            ],
-            "year": [
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/6399849700261888/",
-            "name": "Ceph",
-            "tech": [
-                  "c++",
-                  "python",
-                  "object-storage"
-            ],
-            "cat": "Data and Databases",
-            "top": [
-                  "cloud storage",
-                  "storage"
-            ],
-            "year": [
-                  2017,
-                  2016,
-                  2014
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0,
-                  4,
-                  4,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/5054104644616192/",
-            "name": "Clojure",
-            "tech": [
-                  "clojure",
-                  "clojurescript",
-                  "jvm",
-                  "javascript",
-                  "functional programming"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "programming language",
-                  "development tools",
-                  "compilers",
-                  "functional programming",
-                  "build systems"
-            ],
-            "year": [
-                  2017,
-                  2015,
-                  2014,
-                  2013
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  6,
-                  9,
-                  5,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/5510422639673344/",
-            "name": "CMU Sphinx",
-            "tech": [
-                  "c",
-                  "cross-platform",
-                  "hidden markov models",
-                  "javascript",
-                  "python"
-            ],
-            "cat": "Graphics / Video / Audio / Virtual Reality",
-            "top": [
-                  "speech recognition",
-                  "user interface",
-                  "real time",
-                  "education",
-                  "pronunciation"
-            ],
-            "year": [
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  11,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/6180004551458816/",
-            "name": "Copyleft Games",
-            "tech": [
-                  "python",
-                  "opengl",
-                  "javascript",
-                  "c",
-                  "xmpp"
-            ],
-            "cat": "Graphics / Video / Audio / Virtual Reality",
-            "top": [
-                  "graphics",
-                  "networking",
-                  "web",
-                  "education"
-            ],
-            "year": [
-                  2017,
-                  2016,
-                  2015,
-                  2014
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  5,
-                  8,
-                  2,
-                  2,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/4878856288731136/",
-            "name": "Discourse",
-            "tech": [
-                  "ruby on rails",
-                  "ember",
-                  "ruby",
-                  "javascipt",
-                  "html/css"
-            ],
-            "cat": "Social / Communications",
-            "top": [
-                  "asynchronous",
-                  "forum",
-                  "community",
-                  " real time",
-                  "web development"
-            ],
-            "year": [
-                  2017,
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  4,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/5851994006749184/",
-            "name": "Eclipse Vert.x",
-            "tech": [
-                  "java",
-                  "reactive extensions",
-                  "kotlin",
-                  "microservices",
-                  "event-loop"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "reactive",
-                  "unopionated",
-                  "polyglot",
-                  "distributed",
-                  "high performance computing"
-            ],
-            "year": [
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/5658990390280192/",
-            "name": "Elm Software Foundation",
-            "tech": [
-                  "elm",
-                  "javascript",
-                  "haskell"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "functional programming",
-                  "compilers",
-                  "web applications",
-                  "programming languages",
-                  "user interface"
-            ],
-            "year": [
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/4941941976334336/",
-            "name": "Environmental Data And Governance Initiative",
-            "tech": [
-                  "python",
-                  "javascript",
-                  "ruby on rails",
-                  "google cloud",
-                  "go"
-            ],
-            "cat": "Data and Databases",
-            "top": [
-                  "crawling",
-                  "api",
-                  "open data",
-                  "machine learning",
-                  "open science"
-            ],
-            "year": [
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/6004756195573760/",
-            "name": "Freifunk",
-            "tech": [
-                  "lede/openwrt",
-                  "c",
-                  "html/css",
-                  "shell script",
-                  "javascript"
-            ],
-            "cat": "Social / Communications",
-            "top": [
-                  "wireless",
-                  "routing",
-                  "monitoring",
-                  "firmware development",
-                  "user interface"
-            ],
-            "year": [
-                  2017,
-                  2016,
-                  2014,
-                  2010,
-                  2009
-            ],
-            "project": [
-                  10,
-                  8,
-                  0,
-                  0,
-                  0,
-                  8,
-                  0,
-                  8,
-                  12,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/4597892144693248/",
-            "name": "Frescobaldi",
-            "tech": [
-                  "python",
-                  "pyqt"
-            ],
-            "cat": "End User Applications",
-            "top": [
-                  "music engraving"
-            ],
-            "year": [
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/4914104280023040/",
-            "name": "GENIVI Development Platform",
-            "tech": [
-                  "linux",
-                  "c",
-                  "yocto",
-                  "c++",
-                  "qt"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "automotive",
-                  "cars",
-                  "embedded systems",
-                  "embedded",
-                  "automobile"
-            ],
-            "year": [
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/6147412729004032/",
-            "name": "Green Navigation",
-            "tech": [
-                  "javascript",
-                  "java",
-                  "react",
-                  "apache spark",
-                  "tensorflow"
-            ],
-            "cat": "Other",
-            "top": [
-                  "routing",
-                  "eletric mobility",
-                  "web",
-                  "machine learning"
-            ],
-            "year": [
-                  2017,
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  5,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/6221940343701504/",
-            "name": "illumos.org",
-            "tech": [
-                  "dtrace",
-                  "illumos",
-                  "unix",
-                  "openzfs",
-                  "zfs"
-            ],
-            "cat": "Operating Systems",
-            "top": [
-                  "drivers",
-                  "virtualization",
-                  "storage",
-                  "networking",
-                  "kernel"
-            ],
-            "year": [
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/6149200777576448/",
-            "name": "Intel Media and Audio for Linux",
-            "tech": [
-                  "video",
-                  "decode",
-                  "encode",
-                  "vpp",
-                  "multimedia"
-            ],
-            "cat": "Graphics / Video / Audio / Virtual Reality",
-            "top": [
-                  "accelerated media",
-                  "video",
-                  "compress",
-                  "encoding",
-                  "camera"
-            ],
-            "year": [
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/6380010977886208/",
-            "name": "JSK Robotics Laboratory",
-            "tech": [
-                  "ros",
-                  "lisp",
-                  "prolog",
-                  "openhrp",
-                  "openrtm"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "robotics",
-                  "artificial intelligence"
-            ],
-            "year": [
-                  2017,
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/6184001823834112/",
-            "name": "K-9 Mail",
-            "tech": [
-                  "android",
-                  "java"
-            ],
-            "cat": "End User Applications",
-            "top": [
-                  "email",
-                  "communication"
-            ],
-            "year": [
-                  2017,
-                  2011
-            ],
-            "project": [
-                  0,
-                  0,
-                  4,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/5586250824155136/",
-            "name": "KDE",
-            "tech": [
-                  "c++",
-                  "qt",
-                  "qt5"
-            ],
-            "cat": "End User Applications",
-            "top": [
-                  "desktop",
-                  "desktop application",
-                  "education",
-                  "science",
-                  "communication"
-            ],
-            "year": [
-                  2017,
-                  2016,
-                  2015,
-                  2014,
-                  2013,
-                  2012,
-                  2011,
-                  2010,
-                  2009
-            ],
-            "project": [
-                  37,
-                  46,
-                  47,
-                  59,
-                  50,
-                  39,
-                  36,
-                  32,
-                  24,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/5279287632461824/",
-            "name": "Liquid Galaxy Project",
-            "tech": [
-                  "javascript",
-                  "ros",
-                  "gis",
-                  "cesiumjs"
-            ],
-            "cat": "Graphics / Video / Audio / Virtual Reality",
-            "top": [
-                  "virtual reality",
-                  "geospatial",
-                  "visualisation",
-                  "graphics",
-                  "webvr"
-            ],
-            "year": [
-                  2017,
-                  2016,
-                  2015,
-                  2014,
-                  2013,
-                  2012,
-                  2011
-            ],
-            "project": [
-                  0,
-                  0,
-                  3,
-                  3,
-                  3,
-                  5,
-                  6,
-                  4,
-                  3,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/4752192066027520/",
-            "name": "MariaDB",
-            "tech": [
-                  "mariadb",
-                  "mysql",
-                  "c",
-                  "c++",
-                  "java"
-            ],
-            "cat": "Data and Databases",
-            "top": [
-                  "database"
-            ],
-            "year": [
-                  2017,
-                  2016,
-                  2015,
-                  2014,
-                  2013
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  4,
-                  3,
-                  5,
-                  1,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/5026327212064768/",
-            "name": "Microkernel devroom",
-            "tech": [
-                  "c",
-                  "c++",
-                  "rust",
-                  "arm",
-                  "x86"
-            ],
-            "cat": "Operating Systems",
-            "top": [
-                  "microkernel",
-                  "components",
-                  "ipc",
-                  "desktop",
-                  "virtualization"
-            ],
-            "year": [
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/5486404108812288/",
-            "name": "Mifos Initiative",
-            "tech": [
-                  "java",
-                  "android",
-                  "angularjs",
-                  "spring",
-                  "mysql"
-            ],
-            "cat": "End User Applications",
-            "top": [
-                  "fintech",
-                  "mobile banking",
-                  "digital financial services",
-                  "microfinance",
-                  "financial inclusion"
-            ],
-            "year": [
-                  2017,
-                  2016,
-                  2014
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  7,
-                  0,
-                  6,
-                  10,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/4814565460148224/",
-            "name": "Mono Project",
-            "tech": [
-                  "c#",
-                  ".net",
-                  "f#",
-                  "c"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "compiler",
-                  "ide",
-                  "mobile development",
-                  "web development",
-                  "programming tools"
-            ],
-            "year": [
-                  2017,
-                  2015,
-                  2014,
-                  2013,
-                  2012,
-                  2011,
-                  2009
-            ],
-            "project": [
-                  6,
-                  0,
-                  13,
-                  12,
-                  14,
-                  12,
-                  13,
-                  0,
-                  9,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/5603880054292480/",
-            "name": "Nmap Security Scanner",
-            "tech": [
-                  "c/c++",
-                  "lua",
-                  "python",
-                  "c",
-                  "c++"
-            ],
-            "cat": "Security",
-            "top": [
-                  "security",
-                  "networking",
-                  "ipv6",
-                  "linux",
-                  "network mapping"
-            ],
-            "year": [
-                  2017,
-                  2016,
-                  2015,
-                  2014,
-                  2013,
-                  2012,
-                  2011,
-                  2010,
-                  2009
-            ],
-            "project": [
-                  6,
-                  8,
-                  7,
-                  4,
-                  3,
-                  4,
-                  5,
-                  5,
-                  4,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/6015282623545344/",
-            "name": "Open Detection",
-            "tech": [
-                  "c++",
-                  "caffe",
-                  "pcl",
-                  "opencv"
-            ],
-            "cat": "Other",
-            "top": [
-                  "computer vision",
-                  "ai"
-            ],
-            "year": [
-                  2017,
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  2,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/6266968780832768/",
-            "name": "Open Technologies Alliance - GFOSS",
-            "tech": [
-                  "php",
-                  "java",
-                  "mysql",
-                  "virtuoso",
-                  "python"
-            ],
-            "cat": "Other",
-            "top": [
-                  "data",
-                  "cloud",
-                  "hardware"
-            ],
-            "year": [
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  4,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/5718999941775360/",
-            "name": "oVirt",
-            "tech": [
-                  "java",
-                  "python",
-                  "kvm"
-            ],
-            "cat": "End User Applications",
-            "top": [
-                  "virtualization",
-                  "enterprise application"
-            ],
-            "year": [
-                  2017,
-                  2014
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0,
-                  0,
-                  2,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/5721528872206336/",
-            "name": "ownCloud",
-            "tech": [
-                  "php",
-                  "qt",
-                  "android",
-                  "ios",
-                  "javascript"
-            ],
-            "cat": "Cloud",
-            "top": [
-                  "cloud",
-                  "sync",
-                  "file share"
-            ],
-            "year": [
-                  2017,
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  3,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/6491731667189760/",
-            "name": "Physical Web Project",
-            "tech": [
-                  "beacon",
-                  "web bluetooth",
-                  "physical web",
-                  "bluetooth"
-            ],
-            "cat": "Other",
-            "top": [
-                  "internet of things",
-                  "beacons"
-            ],
-            "year": [
-                  2017,
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  5,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/4530756705583104/",
-            "name": "Plone Foundation",
-            "tech": [
-                  "python",
-                  "javascript",
-                  "html/css"
-            ],
-            "cat": "Web",
-            "top": [
-                  " content management",
-                  "cms"
-            ],
-            "year": [
-                  2017,
-                  2016,
-                  2014,
-                  2013,
-                  2011,
-                  2010,
-                  2009
-            ],
-            "project": [
-                  5,
-                  4,
-                  3,
-                  0,
-                  2,
-                  2,
-                  0,
-                  3,
-                  4,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/5827042528460800/",
-            "name": "Portland State University",
-            "tech": [
-                  "open hardware",
-                  "language-agnostic"
-            ],
-            "cat": "Other",
-            "top": [
-                  "new projects",
-                  "academic projects",
-                  "individual projects"
-            ],
-            "year": [
-                  2017,
-                  2016,
-                  2015,
-                  2014,
-                  2013,
-                  2012,
-                  2011,
-                  2010,
-                  2009
-            ],
-            "project": [
-                  6,
-                  5,
-                  11,
-                  8,
-                  8,
-                  11,
-                  11,
-                  6,
-                  7,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/4795019735072768/",
-            "name": "radare2",
-            "tech": [
-                  "c",
-                  "rust",
-                  "python",
-                  "nodejs"
-            ],
-            "cat": "Security",
-            "top": [
-                  "reverse engineering"
-            ],
-            "year": [
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/4704476053110784/",
-            "name": "Shogun Machine Learning Toolbox",
-            "tech": [
-                  "c/c++",
-                  "python",
-                  "swig",
-                  "machine learning",
-                  "cmake"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "machine learning",
-                  " statistics",
-                  " fast algorithms",
-                  " bioinformatics",
-                  " software engineering"
-            ],
-            "year": [
-                  2017,
-                  2016,
-                  2014,
-                  2013,
-                  2012
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  8,
-                  8,
-                  8,
-                  0,
-                  3,
-                  4,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/5019976297611264/",
-            "name": "Sigmah",
-            "tech": [
-                  "gwt",
-                  "java",
-                  "postgresql"
-            ],
-            "cat": "End User Applications",
-            "top": [
-                  "humanitarian",
-                  "project-management"
-            ],
-            "year": [
-                  2017,
-                  2016,
-                  2014,
-                  2013,
-                  2012
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  2,
-                  3,
-                  3,
-                  0,
-                  1,
-                  2,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/6300304437936128/",
-            "name": "Software Product Data Exchange (SPDX)",
-            "tech": [
-                  "rdf",
-                  "python",
-                  "java",
-                  "github",
-                  "c"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "compliance",
-                  "opensource",
-                  "licensing"
-            ],
-            "year": [
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  4,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/6367868836904960/",
-            "name": "Stony Brook University, Biomedical Informatics",
-            "tech": [
-                  "big data",
-                  "apache spark",
-                  "matlab",
-                  "c++",
-                  "hadoop"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "biomedical informatics",
-                  "medical imaging",
-                  "bioinformtics",
-                  "big data",
-                  "database"
-            ],
-            "year": [
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/4984473024200704/",
-            "name": "Sustainable Computing Research Group ( SCoRe )",
-            "tech": [
-                  "python",
-                  "java",
-                  "gcp",
-                  "android",
-                  "golan"
-            ],
-            "cat": "End User Applications",
-            "top": [
-                  "iot",
-                  "security",
-                  "mobile applications",
-                  "embedded systems"
-            ],
-            "year": [
-                  2017,
-                  2016,
-                  2015
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  7,
-                  16,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/5429781541683200/",
-            "name": "Systers, an Anita Borg Institute community",
-            "tech": [
-                  "android",
-                  "ios",
-                  "python",
-                  "java",
-                  "javascript"
-            ],
-            "cat": "Other",
-            "top": [
-                  "women in tech",
-                  "games",
-                  "peace corps",
-                  "web",
-                  "mobile"
-            ],
-            "year": [
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  11,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/6565611412914176/",
-            "name": "The CGAL Project",
-            "tech": [
-                  "c++",
-                  "git",
-                  "github"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "computational geometry",
-                  "geometry processing",
-                  "mesh processing",
-                  "triangulaton",
-                  "arrangement"
-            ],
-            "year": [
-                  2017,
-                  2013
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  7,
-                  0,
-                  0,
-                  0,
-                  4,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/4699374705704960/",
-            "name": "The FreeType Project",
-            "tech": [
-                  "fonts",
-                  "opentype",
-                  "c",
-                  "library"
-            ],
-            "cat": "Graphics / Video / Audio / Virtual Reality",
-            "top": [
-                  "fonts",
-                  "opentype",
-                  "rendering",
-                  "graphics",
-                  "truetype"
-            ],
-            "year": [
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/6470814639587328/",
-            "name": "Tiled",
-            "tech": [
-                  "qt",
-                  "c++",
-                  "git",
-                  "github"
-            ],
-            "cat": "End User Applications",
-            "top": [
-                  "edit",
-                  "editing",
-                  "level",
-                  "game",
-                  "game development"
-            ],
-            "year": [
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/6543856732471296/",
-            "name": "TimVideos",
-            "tech": [
-                  "python",
-                  "verilog",
-                  "fpga",
-                  "vhdl",
-                  "c"
-            ],
-            "cat": "Graphics / Video / Audio / Virtual Reality",
-            "top": [
-                  "hardware",
-                  "embedded",
-                  "video",
-                  "fpga"
-            ],
-            "year": [
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/5273949793419264/",
-            "name": "Tor",
-            "tech": [
-                  "c",
-                  "python",
-                  "javascript",
-                  "c++"
-            ],
-            "cat": "Security",
-            "top": [
-                  "privacy",
-                  " anonymity",
-                  " counter-censorship",
-                  "free-speech"
-            ],
-            "year": [
-                  2017,
-                  2013
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  6,
-                  0,
-                  0,
-                  0,
-                  4,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/4513544758362112/",
-            "name": "Urban Energy Systems Laboratory, Empa",
-            "tech": [
-                  "python",
-                  "gis",
-                  "fast fluid dynamics"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "distributed energy systems",
-                  "modeling & optimization",
-                  "data portal"
-            ],
-            "year": [
-                  2017,
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  3,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/6393325913374720/",
-            "name": "WorldBrain - Verifying the Internet with Science",
-            "tech": [
-                  "reactjs",
-                  "javascript"
-            ],
-            "cat": "Social / Communications",
-            "top": [
-                  "fake-news",
-                  "misinformation",
-                  "search",
-                  "digital knowledge"
-            ],
-            "year": [
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/6070843662663680/",
-            "name": "WSO2",
-            "tech": [
-                  "soa",
-                  "middleware",
-                  "java",
-                  "distributed computing",
-                  "web services"
-            ],
-            "cat": "Other",
-            "top": [
-                  "cloud",
-                  "iot",
-                  "security",
-                  "micro services",
-                  "api management"
-            ],
-            "year": [
-                  2017,
-                  2016,
-                  2015,
-                  2014
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  5,
-                  9,
-                  11,
-                  9,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/5262324659126272/",
-            "name": "wxWidgets",
-            "tech": [
-                  "c++",
-                  "gtk+",
-                  "win32",
-                  "cocoa"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "cross-platform",
-                  "desktop",
-                  "gui"
-            ],
-            "year": [
-                  2017,
-                  2014,
-                  2011,
-                  2010,
-                  2009
-            ],
-            "project": [
-                  3,
-                  5,
-                  3,
-                  0,
-                  0,
-                  6,
-                  0,
-                  0,
-                  2,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/5748328394391552/",
-            "name": "Xen Project",
-            "tech": [
-                  "linux",
-                  "free/netbsd",
-                  "asm/c/c++",
-                  "qemu",
-                  "ocaml"
-            ],
-            "cat": "Cloud",
-            "top": [
-                  "virtualization",
-                  "security",
-                  "cloud computing",
-                  "unikernels",
-                  "embedded/automotive"
-            ],
-            "year": [
-                  2017,
-                  2014
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  5,
-                  0,
-                  0,
-                  2,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/4744852235354112/",
-            "name": "Zenodo",
-            "tech": [
-                  "python",
-                  "postgresql",
-                  "flask",
-                  "angularjs",
-                  "elasticsearch"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "content management",
-                  "web",
-                  "open science",
-                  "digital library",
-                  "machine learning"
-            ],
-            "year": [
-                  2017
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/5127141637226496/",
-            "name": "AOSSIE - The Australian National University's Open-Source Software Innovation and Education",
-            "tech": [
-                  "scala",
-                  "lisp",
-                  "llvm",
-                  "python",
-                  "postgresql"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "logic",
-                  "live programming",
-                  "data analysis",
-                  "health",
-                  "privacy"
-            ],
-            "year": [
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  6,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/6488526010974208/",
-            "name": "ArchC",
-            "tech": [
-                  "c++",
-                  "python",
-                  "archc"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "computer architecture",
-                  "processor design",
-                  "simulators"
-            ],
-            "year": [
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/5175650340044800/",
-            "name": "ASCEND",
-            "tech": [
-                  "python",
-                  "c",
-                  "c/c++"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "engineering",
-                  "simulation",
-                  "system modelling",
-                  "mathematical software",
-                  "solver"
-            ],
-            "year": [
-                  2016,
-                  2015,
-                  2012,
-                  2011,
-                  2010,
-                  2009
-            ],
-            "project": [
-                  5,
-                  4,
-                  6,
-                  6,
-                  0,
-                  0,
-                  5,
-                  3,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/6488734048452608/",
-            "name": "Berkman Center for Internet and Society",
-            "tech": [
-                  "ruby on rails",
-                  "javascript",
-                  "sql/nosql",
-                  "meteor.js",
-                  "go"
-            ],
-            "cat": "",
-            "top": [
-                  "censorship",
-                  "education",
-                  "internet freedom",
-                  "digital rights",
-                  "law and policy"
-            ],
-            "year": [
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  10,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/6650532982685696/",
-            "name": "BioJS",
-            "tech": [
-                  "javascript",
-                  "python"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "javascript",
-                  "bioinformatics",
-                  "life sciences",
-                  "coding standards",
-                  "visualization"
-            ],
-            "year": [
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/4929075730710528/",
-            "name": "BuildmLearn",
-            "tech": [
-                  "python",
-                  "django",
-                  "bootstrap",
-                  "android"
-            ],
-            "cat": "End User Applications",
-            "top": [
-                  "mlearning",
-                  "mobile app",
-                  "web apps",
-                  "education"
-            ],
-            "year": [
-                  2016,
-                  2015,
-                  2014
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  6,
-                  4,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/5630110493310976/",
-            "name": "Canadian Centre for Computational Genomics (C3G) - Montreal node",
-            "tech": [
-                  "python",
-                  "r-project",
-                  "javascript",
-                  "sql",
-                  "git"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "bioinformatics",
-                  "visualization",
-                  "statistics",
-                  "genomics",
-                  "population genetics"
-            ],
-            "year": [
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/4955769220890624/",
-            "name": "Celluloid",
-            "tech": [
-                  "ruby",
-                  "multi-threading",
-                  "multi-core",
-                  "zeromq",
-                  "high-resolution timers"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "concurrency",
-                  "parallel",
-                  "evented",
-                  "distributed",
-                  "actor model"
-            ],
-            "year": [
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/6273708926697472/",
-            "name": "CERN SFT",
-            "tech": [
-                  "c++",
-                  "python",
-                  "javascript",
-                  "clang"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "numerical and data analysis software",
-                  "simulation software",
-                  "cloud",
-                  "machine learning"
-            ],
-            "year": [
-                  2016,
-                  2015,
-                  2014,
-                  2013,
-                  2012
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  7,
-                  8,
-                  11,
-                  14,
-                  10,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/5902411419877376/",
-            "name": "Computational Science and Engineering at TU Wien",
-            "tech": [
-                  "javascript",
-                  "html",
-                  "css",
-                  "java",
-                  "c++"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "science and enineering",
-                  "internet of things",
-                  "visualization",
-                  "simulation",
-                  "mesh generation"
-            ],
-            "year": [
-                  2016,
-                  2014,
-                  2013,
-                  2012,
-                  2011
-            ],
-            "project": [
-                  0,
-                  0,
-                  3,
-                  9,
-                  12,
-                  14,
-                  0,
-                  10,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/6020075270176768/",
-            "name": "CVXPY",
-            "tech": [
-                  "python"
-            ],
-            "cat": "",
-            "top": [
-                  "convex optimization",
-                  "optimization",
-                  "dsl"
-            ],
-            "year": [
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/4688223091556352/",
-            "name": "D Foundation",
-            "tech": [
-                  "dlang",
-                  "c++"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "compilers"
-            ],
-            "year": [
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  4,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/6313893177589760/",
-            "name": "dbpediaspotlight",
-            "tech": [
-                  "java",
-                  "scala",
-                  "rdf",
-                  "python",
-                  "nosql"
-            ],
-            "cat": "Data and Databases",
-            "top": [
-                  "natural language processing",
-                  "big data",
-                  "semantic web",
-                  "data science"
-            ],
-            "year": [
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  8,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/5457125316755456/",
-            "name": "Distributed and Unified Numerics Environment (DUNE)",
-            "tech": [
-                  "c++",
-                  "python",
-                  "cmake"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "partial differential equations",
-                  "physics",
-                  "mathematics",
-                  "high performance computing",
-                  "scientific computing"
-            ],
-            "year": [
-                  2016,
-                  2013
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0,
-                  0,
-                  2,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/4603925500002304/",
-            "name": "FOSDEM VZW",
-            "tech": [
-                  "ruby on rails",
-                  "postgresql",
-                  "git"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "web",
-                  "programming tools",
-                  "programming",
-                  "programming languages",
-                  "ruby"
-            ],
-            "year": [
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/6393779032424448/",
-            "name": "Gambit - Software Tools for Game Theory",
-            "tech": [
-                  "javascript"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "game theory",
-                  "academic projects",
-                  "graphics"
-            ],
-            "year": [
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/5865050841546752/",
-            "name": "Ganeti",
-            "tech": [
-                  "python",
-                  "haskell",
-                  "kvm",
-                  "xen",
-                  "virtualization"
-            ],
-            "cat": "",
-            "top": [
-                  "virtualization",
-                  "automation"
-            ],
-            "year": [
-                  2016,
-                  2015,
-                  2014,
-                  2013
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  2,
-                  1,
-                  1,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/5632763172487168/",
-            "name": "GitHub",
-            "tech": [
-                  "git",
-                  "atom",
-                  "node.js",
-                  "ruby",
-                  "c#"
-            ],
-            "cat": "",
-            "top": [
-                  "git",
-                  "version control",
-                  "editor",
-                  "collaboration"
-            ],
-            "year": [
-                  2016,
-                  2015
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  5,
-                  4,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/6536303764045824/",
-            "name": "Global Alliance for Genomics & Health",
-            "tech": [
-                  "python",
-                  "java",
-                  "protobuf",
-                  "sql"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "genomics",
-                  "big data",
-                  "standards",
-                  "apis",
-                  "data sharing"
-            ],
-            "year": [
-                  2016,
-                  2015
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  3,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/5800194151022592/",
-            "name": "gnss-sdr",
-            "tech": [
-                  "c/c++",
-                  "c++11",
-                  "c++14",
-                  "gnss"
-            ],
-            "cat": "Social / Communications",
-            "top": [
-                  "communications",
-                  "geolocation",
-                  "navigation",
-                  "software defined radio"
-            ],
-            "year": [
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/5849050746191872/",
-            "name": "Health Information Systems Programme",
-            "tech": [
-                  "java",
-                  "android",
-                  "javascript",
-                  "reactjs",
-                  "gradle"
-            ],
-            "cat": "",
-            "top": [
-                  "mobile",
-                  "data processing",
-                  "gis",
-                  "e-health",
-                  "global health and development"
-            ],
-            "year": [
-                  2016,
-                  2014,
-                  2013
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  4,
-                  5,
-                  0,
-                  6,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/5096012251136000/",
-            "name": "Indic Project",
-            "tech": [
-                  "android",
-                  "python",
-                  "javascript",
-                  "ruby on rails",
-                  "c++"
-            ],
-            "cat": "End User Applications",
-            "top": [
-                  "natural language processing",
-                  "language techology",
-                  "input methods"
-            ],
-            "year": [
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  7,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/6563422992859136/",
-            "name": "International Neuroinformatics Coordinating Facility",
-            "tech": [
-                  "c++",
-                  "python",
-                  "gpu",
-                  "javascript",
-                  "java"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "neuroscience",
-                  "data science",
-                  "simulation",
-                  "visualization",
-                  "big data"
-            ],
-            "year": [
-                  2016,
-                  2015,
-                  2014,
-                  2013,
-                  2012,
-                  2011
-            ],
-            "project": [
-                  0,
-                  0,
-                  2,
-                  6,
-                  6,
-                  12,
-                  12,
-                  12,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/4723150839349248/",
-            "name": "Java Pathfinder Team",
-            "tech": [
-                  "java",
-                  "jvm",
-                  "android",
-                  "distributed systems"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "program analysis",
-                  "testing",
-                  "verification",
-                  "model checking",
-                  "environment generation"
-            ],
-            "year": [
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  10,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/4879888423059456/",
-            "name": "Jenkins Project",
-            "tech": [
-                  "java",
-                  "groovy",
-                  "jenkins",
-                  "css",
-                  "html"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "automation",
-                  "continuous integration",
-                  "continuous delivery",
-                  "java",
-                  "development"
-            ],
-            "year": [
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/5754903989321728/",
-            "name": "jQuery Foundation",
-            "tech": [
-                  "javascript",
-                  "html5",
-                  "css",
-                  "jquery"
-            ],
-            "cat": "",
-            "top": [
-                  "unit testing",
-                  "software testing",
-                  "framework development",
-                  "user interface components",
-                  "event handling"
-            ],
-            "year": [
-                  2016,
-                  2015
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  7,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/5678701068943360/",
-            "name": "KolibriOS",
-            "tech": [
-                  "fasm",
-                  "flat assembler",
-                  "x86 assembly",
-                  "i386",
-                  "i586"
-            ],
-            "cat": "Operating Systems",
-            "top": [
-                  "desktop",
-                  "operating systems",
-                  "drivers",
-                  "hardware",
-                  "lowlevel"
-            ],
-            "year": [
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  4,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/6241651022364672/",
-            "name": "MBDyn, Department of Aerospace Science and Technology at Politecnico di Milano",
-            "tech": [
-                  "c++"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "physics",
-                  "engineering",
-                  "simulation",
-                  "robotics",
-                  "real time"
-            ],
-            "year": [
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/4739150934704128/",
-            "name": "McGill Space Institute",
-            "tech": [
-                  "python",
-                  "sql",
-                  "databases",
-                  "big data"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "space",
-                  "astronomy"
-            ],
-            "year": [
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/4969202133762048/",
-            "name": "MetaBrainz Foundation",
-            "tech": [
-                  "python",
-                  "perl",
-                  "postgresql",
-                  "javascript"
-            ],
-            "cat": "Data and Databases",
-            "top": [
-                  "music",
-                  "metadata",
-                  "machine learning",
-                  "big data",
-                  "books"
-            ],
-            "year": [
-                  2016,
-                  2009
-            ],
-            "project": [
-                  2,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  4,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/5954860486754304/",
-            "name": "MIT Media Lab",
-            "tech": [
-                  "java",
-                  "html/javascript",
-                  "android"
-            ],
-            "cat": "End User Applications",
-            "top": [
-                  "educational technology",
-                  "education"
-            ],
-            "year": [
-                  2016,
-                  2015
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  6,
-                  5,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/5115751115522048/",
-            "name": "mlpack: a scalable C++ machine learning library",
-            "tech": [
-                  "c++"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "machine learning",
-                  "data mining",
-                  "fast algorithms"
-            ],
-            "year": [
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  6,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/6377072951820288/",
-            "name": "ModSecurity",
-            "tech": [
-                  "waf",
-                  "web application firewall"
-            ],
-            "cat": "Security",
-            "top": [
-                  "web application security"
-            ],
-            "year": [
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/5166380995313664/",
-            "name": "Open Ephys",
-            "tech": [
-                  "c++",
-                  "juce"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "neuroscience",
-                  "electrophysiology",
-                  "visualization",
-                  "ui",
-                  "signal processing"
-            ],
-            "year": [
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/5672889575538688/",
-            "name": "OpenKeychain (OpenPGP for Android)",
-            "tech": [
-                  "android",
-                  "openpgp"
-            ],
-            "cat": "Security",
-            "top": [
-                  "security",
-                  "e-mail",
-                  "encryption"
-            ],
-            "year": [
-                  2016,
-                  2015,
-                  2014
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  2,
-                  2,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/6400146589876224/",
-            "name": "Orange \u2013 Data Mining Fruitful & Fun",
-            "tech": [
-                  "python",
-                  "cython",
-                  "qt",
-                  "machine learning"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "machine learning",
-                  "visualization",
-                  "data mining",
-                  "bioinformatics",
-                  "gui toolkit"
-            ],
-            "year": [
-                  2016,
-                  2012,
-                  2011
-            ],
-            "project": [
-                  0,
-                  0,
-                  3,
-                  3,
-                  0,
-                  0,
-                  0,
-                  5,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/6434461499523072/",
-            "name": "OSGeo - The Open Source Geospatial Foundation",
-            "tech": [
-                  "python",
-                  "sql",
-                  "c",
-                  "ogc standards",
-                  "c++"
-            ],
-            "cat": "",
-            "top": [
-                  "gis",
-                  "science",
-                  "maps",
-                  "cartography",
-                  "geospatial"
-            ],
-            "year": [
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  20,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/4845666660515840/",
-            "name": "OSU Open Source Lab",
-            "tech": [
-                  "python",
-                  "rest",
-                  "javascript",
-                  "ruby"
-            ],
-            "cat": "",
-            "top": [
-                  "virtualization",
-                  "infrastructure"
-            ],
-            "year": [
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/5191954035900416/",
-            "name": "Peragro",
-            "tech": [
-                  "python",
-                  "blender",
-                  "javascript",
-                  "celery",
-                  "django"
-            ],
-            "cat": "",
-            "top": [
-                  "analyzing",
-                  "transcoding",
-                  "pipeline automation",
-                  "games",
-                  "web"
-            ],
-            "year": [
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/6066521583386624/",
-            "name": "PLASMA-UMass",
-            "tech": [
-                  "javascript",
-                  "c/c++",
-                  "scala",
-                  "go"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "programming languages",
-                  "programming tools",
-                  "software engineering",
-                  "operating systems",
-                  "runtime systems"
-            ],
-            "year": [
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/4609839401533440/",
-            "name": "PRISM Model Checker",
-            "tech": [
-                  "java",
-                  "c++"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "science",
-                  "verification",
-                  "probabilistic models"
-            ],
-            "year": [
-                  2016,
-                  2014,
-                  2013
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  8,
-                  0,
-                  5,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/6723762711953408/",
-            "name": "Robocomp",
-            "tech": [
-                  "c++",
-                  "python",
-                  "zeroc ice",
-                  "cmake",
-                  "gnu/linux"
-            ],
-            "cat": "",
-            "top": [
-                  "robotics",
-                  "framework",
-                  "computer vision"
-            ],
-            "year": [
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  5,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/5960176045654016/",
-            "name": "Scilab Enterprises",
-            "tech": [
-                  "scilab",
-                  "c++",
-                  "java",
-                  "c",
-                  "fortran"
-            ],
-            "cat": "Science and Medicine",
-            "top": [
-                  "engineering",
-                  "mechanics",
-                  "vision",
-                  "graphics",
-                  "user interface"
-            ],
-            "year": [
-                  2016,
-                  2015
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  4,
-                  5,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/6477188102619136/",
-            "name": "Soletta Project",
-            "tech": [
-                  "c",
-                  "python",
-                  "javascript",
-                  "networking",
-                  "machine learning"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "internet of things",
-                  "portable",
-                  "robotics",
-                  "drones",
-                  "makers"
-            ],
-            "year": [
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/5689792285114368/",
-            "name": "Systers, an Anita Borg Institute Community",
-            "tech": [
-                  "python",
-                  "android",
-                  "ios",
-                  "mysql",
-                  "ruby on rails"
-            ],
-            "cat": "",
-            "top": [
-                  "women in tech",
-                  "systers",
-                  "women in open source"
-            ],
-            "year": [
-                  2016,
-                  2015,
-                  2014,
-                  2013
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  6,
-                  13,
-                  22,
-                  19,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/5377487227846656/",
-            "name": "The Apertium Project",
-            "tech": [
-                  "c++",
-                  "python",
-                  "perl",
-                  "xml",
-                  "finite-state technologies"
-            ],
-            "cat": "Social / Communications",
-            "top": [
-                  "machine translation",
-                  "computer-aided translation",
-                  "morphological analysis",
-                  "natural language processing",
-                  "human language technologies"
-            ],
-            "year": [
-                  2016,
-                  2009
-            ],
-            "project": [
-                  8,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  11,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/5269666368847872/",
-            "name": "The Monarch Initiative",
-            "tech": [
-                  "semantic web",
-                  "javascript",
-                  "text mining",
-                  "named entity recognition",
-                  "ontologies"
-            ],
-            "cat": "End User Applications",
-            "top": [
-                  "embeddable widget",
-                  "rare disease",
-                  "data refinement"
-            ],
-            "year": [
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/6112304055713792/",
-            "name": "The STE||AR Group",
-            "tech": [
-                  "parallel processing",
-                  "high performance computing",
-                  "c++",
-                  "cuda",
-                  "opencl"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "runtime systems",
-                  "parallel computing",
-                  "high performance computing",
-                  "hpx",
-                  "gpu"
-            ],
-            "year": [
-                  2016,
-                  2015,
-                  2014
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  5,
-                  4,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/4906518294036480/",
-            "name": "The syslog-ng project",
-            "tech": [
-                  "c",
-                  "java",
-                  "python",
-                  "big data",
-                  "rust"
-            ],
-            "cat": "Security",
-            "top": [
-                  "log management",
-                  "message queue",
-                  "data extraction",
-                  "message correlation",
-                  "continuous delivery"
-            ],
-            "year": [
-                  2016,
-                  2015,
-                  2014
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  4,
-                  4,
-                  4,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/6183886396588032/",
-            "name": "The Tor Project",
-            "tech": [
-                  "c",
-                  "javascript",
-                  "golang",
-                  "python",
-                  "browser extensions"
-            ],
-            "cat": "Security",
-            "top": [
-                  "privacy",
-                  "security",
-                  "anonymity",
-                  "anti-censorship",
-                  "research"
-            ],
-            "year": [
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  5,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/6356852245790720/",
-            "name": "Timelab Technologies Ltd.",
-            "tech": [
-                  "python",
-                  "javascript"
-            ],
-            "cat": "End User Applications",
-            "top": [
-                  "astronomy",
-                  "algorithm prototyping/visualization",
-                  "mathematics",
-                  "time series"
-            ],
-            "year": [
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/6601174413213696/",
-            "name": "Unitex/GramLab",
-            "tech": [
-                  "java",
-                  "c++"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "natural language processing",
-                  "local grammars",
-                  "finite state automata",
-                  "corpus annotation",
-                  "multilingual language resources"
-            ],
-            "year": [
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  2,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/5126842331693056/",
-            "name": "Vert.x",
-            "tech": [
-                  "java",
-                  "reactive",
-                  "javascript",
-                  "groovy",
-                  "micro-services"
-            ],
-            "cat": "Programming Languages and Development Tools",
-            "top": [
-                  "micro services",
-                  "high performance computing"
-            ],
-            "year": [
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/4704929172160512/",
-            "name": "VideoLAN / VLMC Project",
-            "tech": [
-                  "opengl",
-                  "c++",
-                  "c",
-                  "assembly",
-                  "qt"
-            ],
-            "cat": "Graphics / Video / Audio / Virtual Reality",
-            "top": [
-                  "video",
-                  "multimedia",
-                  "editor",
-                  "editing",
-                  "non-linear"
-            ],
-            "year": [
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  3,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      },
-      {
-            "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/4886349127614464/",
-            "name": "Wayland",
-            "tech": [
-                  "opengl",
-                  "wayland",
-                  "c",
-                  "xml",
-                  "kms"
-            ],
-            "cat": "Graphics / Video / Audio / Virtual Reality",
-            "top": [
-                  "graphics",
-                  "window system",
-                  "display",
-                  "video"
-            ],
-            "year": [
-                  2016
-            ],
-            "project": [
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  0,
-                  1,
-                  0,
-                  0,
-                  0,
-                  0
-            ]
-      }
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5129526253715456/",
+        "name": "52\u00b0 North GmbH",
+        "tech": [
+            "java",
+            "android",
+            "javascript",
+            "python",
+            "react",
+            "ogc standards",
+            "web services"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "web services",
+            "floating car data",
+            "ogc standards",
+            "trajectory analytics",
+            "spatial information infrastructures",
+            "citizen science",
+            "open standards",
+            "geoinformation systems"
+        ],
+        "year": [
+            2021,
+            2020
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            3
+        ]
+    },
+    {
+        "name": "AFLplusplus",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5090910303420416/",
+        "tech": [
+            "fuzzing",
+            "instrumentation",
+            "c/c++",
+            "rust",
+            "llvm"
+        ],
+        "cat": "Security",
+        "top": [
+            "fuzzing",
+            "secure development",
+            "instrumentation"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6689005560659968/",
+        "name": "AboutCode.org",
+        "tech": [
+            "python",
+            "c/c++",
+            "rust",
+            "javascript",
+            "postgresql"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "dependencies",
+            "license-scan",
+            "application security",
+            "software analysis",
+            "machine learning"
+        ],
+        "year": [
+            2020,
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            5,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6043464124334080/",
+        "name": "Academy Software Foundation (ASWF)",
+        "tech": [
+            "c/c++",
+            "python"
+        ],
+        "cat": "Graphics / Video / Audio / Virtual Reality",
+        "top": [
+            "2d/3d graphics",
+            "cloud computing",
+            "file formats",
+            "color management",
+            "filmmaking"
+        ],
+        "year": [
+            2020
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/4826533859950592/",
+        "name": "Accord Project",
+        "tech": [
+            "javascript",
+            "react",
+            "coq",
+            "ocaml",
+            "compiler"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "smart contracts",
+            "legal",
+            "blockchain",
+            "compilers",
+            "ai"
+        ],
+        "year": [
+            2021,
+            2020
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            3
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/4866654592303104/",
+        "name": "AerospaceResearch.net",
+        "tech": [
+            "python",
+            "vhdl",
+            "raspberry pi",
+            "sqlite",
+            "c++",
+            "machine learning",
+            "sdr"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "cubesats",
+            "space applications",
+            "software defined radio",
+            "distributed computing",
+            "simulations",
+            "signal processing"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            6,
+            6,
+            7,
+            5,
+            6
+        ]
+    },
+    {
+        "name": "AnkiDroid",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5687189203058688/",
+        "tech": [
+            "java",
+            "javascript",
+            "gradle",
+            "android"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "android",
+            "user generated content",
+            "flashcard",
+            "education"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2
+        ]
+    },
+    {
+        "name": "Audacity",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5631107231383552/",
+        "tech": [
+            "c++"
+        ],
+        "cat": "Graphics / Video / Audio / Virtual Reality",
+        "top": [
+            "audio editor",
+            "audio",
+            "audio analysis",
+            "audio processing"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2
+        ]
+    },
+    {
+        "name": "Bench-Routes",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5764622900002816/",
+        "tech": [
+            "golang",
+            "docker",
+            "react"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "time-series",
+            "monitoring",
+            "web",
+            "devops"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2
+        ]
+    },
+    {
+        "name": "CASTOR",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6291016608382976/",
+        "tech": [
+            "java",
+            "scala",
+            "bytecode"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "testing",
+            "optimization",
+            "development",
+            "automated program repair",
+            "software analysis"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2
+        ]
+    },
+    {
+        "name": "CHAOSS Project",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5959947107434496/",
+        "tech": [
+            "python",
+            "vue",
+            "elk",
+            "nltk",
+            "fossology"
+        ],
+        "cat": "Other",
+        "top": [
+            "community",
+            "metrics",
+            "analytics",
+            "dependencies",
+            "diversity and inclusion"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            6
+        ]
+    },
+    {
+        "name": "CNCF",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5144170817126400/",
+        "tech": [
+            "kubernetes",
+            "go",
+            "rust"
+        ],
+        "cat": "Cloud",
+        "top": [
+            "cloud computing"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            16
+        ]
+    },
+    {
+        "name": "Center for Research in Open Source Software, UC Santa Cruz",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6311773715562496/",
+        "tech": [
+            "c/c++",
+            "c++17",
+            "arrow",
+            "ceph",
+            "robotics"
+        ],
+        "cat": "Other",
+        "top": [
+            "hardware",
+            "storage",
+            "databases",
+            "sensors",
+            "callibration"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            5
+        ]
+    },
+    {
+        "name": "Chromium",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/4857406487527424/",
+        "tech": [
+            "c++",
+            "java",
+            "git",
+            "javascript",
+            "python"
+        ],
+        "cat": "Web",
+        "top": [
+            "web",
+            "browser",
+            "operating-system"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            9
+        ]
+    },
+    {
+        "name": "Cilium",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6055505163714560/",
+        "tech": [
+            "ebpf",
+            "kubernetes",
+            "c",
+            "go",
+            "linux"
+        ],
+        "cat": "Cloud",
+        "top": [
+            "cloud-native",
+            "networking",
+            "kernel"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3
+        ]
+    },
+    {
+        "name": "DeepPavlov",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6618455117135872/",
+        "tech": [
+            "python",
+            "docker",
+            "python deep learning frameworks",
+            "tensorflow",
+            "pytorch"
+        ],
+        "cat": "Other",
+        "top": [
+            "nlp",
+            "conversational",
+            "agent"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3
+        ]
+    },
+    {
+        "name": "Department of Biomedical Informatics (BMI), Emory University School of Medicine",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6515383720214528/",
+        "tech": [
+            "python",
+            "java",
+            "deeplearning",
+            "medical imaging",
+            "tensorflow"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "science and medicine",
+            "data integration",
+            "distributed systems",
+            "cloud",
+            "workflows"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            6
+        ]
+    },
+    {
+        "name": "Elm Tooling",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5833213695492096/",
+        "tech": [
+            "elm",
+            "functional programming",
+            "typescript"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "tooling",
+            "linter",
+            "parser",
+            "web"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2
+        ]
+    },
+    {
+        "name": "Fortran-lang",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6542461173760000/",
+        "tech": [
+            "fortran",
+            "python",
+            "c/c++",
+            "compiler",
+            "llvm"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "science",
+            "engineering",
+            "high-performance computing",
+            "libraries",
+            "numerical computing"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            5
+        ]
+    },
+    {
+        "name": "GFOSS - Open Technology Alliance",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5185060013080576/",
+        "tech": [
+            "python",
+            "javascript",
+            "mysql",
+            "python deep learning frameworks",
+            "perl"
+        ],
+        "cat": "Other",
+        "top": [
+            "python",
+            "java",
+            "javascript",
+            "open hardware",
+            "perl"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            9
+        ]
+    },
+    {
+        "name": "GNOME Foundation",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6476318677401600/",
+        "tech": [
+            "gtk",
+            "python",
+            "c",
+            "javascript",
+            "rust"
+        ],
+        "cat": "Operating Systems",
+        "top": [
+            "desktop",
+            "design",
+            "operating system",
+            "end user application",
+            "application"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            12
+        ]
+    },
+    {
+        "name": "GNU Mailman Project",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5211080233582592/",
+        "tech": [
+            "python",
+            "django",
+            "restful api",
+            "sqlalchemy"
+        ],
+        "cat": "Social / Communications",
+        "top": [
+            "mail",
+            "web"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "name": "GRR Rapid Response",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5763186065670144/",
+        "tech": [
+            "python 3",
+            "angular",
+            "typescript",
+            "materialui",
+            "backend"
+        ],
+        "cat": "Security",
+        "top": [
+            "computer security",
+            "digital forensics"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "name": "Genome Assembly and Annotation",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5794597745197056/",
+        "tech": [
+            "python",
+            "rust",
+            "pytorch",
+            "javascript",
+            "mysql"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "deep learning",
+            "cloud",
+            "genomics",
+            "data science",
+            "workflows"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3
+        ]
+    },
+    {
+        "name": "GitLab",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5396515480141824/",
+        "tech": [
+            "ruby",
+            "git",
+            "ci",
+            "devops",
+            "golang"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "devops"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            4
+        ]
+    },
+    {
+        "name": "Google FHIR SDK",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5675929577193472/",
+        "tech": [
+            "fhir",
+            "android",
+            "kotlin",
+            "sqlite",
+            "materialui"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "global health",
+            "ai",
+            "precision health",
+            "gis",
+            "enteprise analytics"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            5
+        ]
+    },
+    {
+        "name": "Halide",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5630773431894016/",
+        "tech": [
+            "llvm",
+            "c++"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "compilers",
+            "graphics",
+            "high-performance computing",
+            "computer vision"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2
+        ]
+    },
+    {
+        "name": "Integrated Ocean Observing System (IOOS)",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5159672092295168/",
+        "tech": [
+            "python",
+            "big data science",
+            "ocean technology"
+        ],
+        "cat": "Other",
+        "top": [
+            "earth sciences",
+            "data science",
+            "open data",
+            "data discovery"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3
+        ]
+    },
+    {
+        "name": "Intel Video and Audio for Linux",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6244611265134592/",
+        "tech": [
+            "ffmpeg",
+            "gstreamer",
+            "libxcam",
+            "vaapi"
+        ],
+        "cat": "Graphics / Video / Audio / Virtual Reality",
+        "top": [
+            "graphics / video / audio / virtual reality",
+            "360 stereo video",
+            "ffmpeg neuronetwork"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3
+        ]
+    },
+    {
+        "name": "International Catrobat Association",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5201744182640640/",
+        "tech": [
+            "android",
+            "swift",
+            "php",
+            "javascript",
+            "kotlin"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "visual programming",
+            "mobile programming",
+            "game engines",
+            "creativity tools",
+            "education"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            13
+        ]
+    },
+    {
+        "name": "JabRef e.V.",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5760795715043328/",
+        "tech": [
+            "java",
+            "javafx",
+            "bibtex",
+            "latex",
+            "typescript"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "science",
+            "literature",
+            "library"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2
+        ]
+    },
+    {
+        "name": "Java PathFinder",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5712237452328960/",
+        "tech": [
+            "android",
+            "distributed systems",
+            "java",
+            "jvm"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "model checking",
+            "symbolic execution",
+            "verification of concurrent systems",
+            "program analysis",
+            "jvm"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3
+        ]
+    },
+    {
+        "name": "Kodi",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5186500538400768/",
+        "tech": [
+            "c++",
+            "ffmpeg",
+            "sqlite",
+            "python",
+            "opengl"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "media",
+            "video",
+            "audio",
+            "games"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2
+        ]
+    },
+    {
+        "name": "Learning Equality",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5523941925322752/",
+        "tech": [
+            "django",
+            "vue.js",
+            "python",
+            "javascript"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "offline",
+            "distributed databases",
+            "education",
+            "learning"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1
+        ]
+    },
+    {
+        "name": "LibreCube Initiative",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5642529495580672/",
+        "tech": [
+            "python",
+            "micropython",
+            "zmq",
+            "mbed"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "space",
+            "cubesat",
+            "mission control"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2
+        ]
+    },
+    {
+        "name": "Machine Learning for Science (ML4SCI) Umbrella Organization",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5101210708738048/",
+        "tech": [
+            "python",
+            "machine learning",
+            "c/c++",
+            "data analysis",
+            "artificial intelligence"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "science and medicine",
+            "machine learning",
+            "physics",
+            "astronomy",
+            "algorithms"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            19
+        ]
+    },
+    {
+        "name": "MapAction",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/4875496487124992/",
+        "tech": [
+            "python",
+            "apache airflow",
+            "data analysis",
+            "gis",
+            "visualization"
+        ],
+        "cat": "Other",
+        "top": [
+            "humanitarian",
+            "maps",
+            "google cloud",
+            "data processing",
+            "geospatial"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1
+        ]
+    },
+    {
+        "name": "Mayor's Office of New Urban Mechanics (City of Boston)",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5504645576785920/",
+        "tech": [
+            "python",
+            "javascript"
+        ],
+        "cat": "Other",
+        "top": [
+            "machine learning",
+            "civic tech",
+            "web",
+            "gis"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3
+        ]
+    },
+    {
+        "name": "Media Cloud",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6194875543846912/",
+        "tech": [
+            "javascript",
+            "python",
+            "react",
+            "docker",
+            "postgresql"
+        ],
+        "cat": "Other",
+        "top": [
+            "media",
+            "news-media",
+            "media-analytics",
+            "civic-tech",
+            "research"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "name": "MediaPipe",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5917807371354112/",
+        "tech": [
+            "android",
+            "ios",
+            "python",
+            "javascript",
+            "c++"
+        ],
+        "cat": "Graphics / Video / Audio / Virtual Reality",
+        "top": [
+            "real-time",
+            "machine learning",
+            "computer vision",
+            "ml-inference",
+            "deep learning"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            6
+        ]
+    },
+    {
+        "name": "MetaCall",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5272300328321024/",
+        "tech": [
+            "c/c++",
+            "javascript",
+            "python",
+            "cmake",
+            "guix"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "development tools",
+            "programming languages",
+            "polyglot",
+            "foreign function interface",
+            "cross-platform"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3
+        ]
+    },
+    {
+        "name": "Navidrome",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5963988000571392/",
+        "tech": [
+            "react",
+            "golang",
+            "ffmpeg"
+        ],
+        "cat": "Web",
+        "top": [
+            "music",
+            "web",
+            "streaming"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1
+        ]
+    },
+    {
+        "name": "OSGeo - Open Source Geospatial Foundation",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5115040503431168/",
+        "tech": [
+            "python",
+            "c/c++",
+            "javascript",
+            "sql",
+            "java"
+        ],
+        "cat": "Other",
+        "top": [
+            "routing",
+            "databases",
+            "gis",
+            "open science",
+            "citizen science"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            12
+        ]
+    },
+    {
+        "name": "Open Robotics",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5698036243628032/",
+        "tech": [
+            "ros",
+            "gazebo",
+            "ignition",
+            "c/c++",
+            "python"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "robotics"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2
+        ]
+    },
+    {
+        "name": "Pidgin Instant Messenger",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5646348627476480/",
+        "tech": [
+            "c",
+            "gtk",
+            "gstreamer"
+        ],
+        "cat": "Social / Communications",
+        "top": [
+            "chat",
+            "web",
+            "real time",
+            "voice",
+            "video"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1
+        ]
+    },
+    {
+        "name": "Plan 9 Foundation",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5118711358291968/",
+        "tech": [
+            "c",
+            "distributed systems",
+            "concurrency",
+            "golang"
+        ],
+        "cat": "Operating Systems",
+        "top": [
+            "operating systems",
+            "distributed systems",
+            "network programming"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2
+        ]
+    },
+    {
+        "name": "Polypheny",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5697965007568896/",
+        "tech": [
+            "java",
+            "javascript",
+            "angular",
+            "sql"
+        ],
+        "cat": "Data and Databases",
+        "top": [
+            "polystore",
+            "databases",
+            "nosql",
+            "ui",
+            "big data"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3
+        ]
+    },
+    {
+        "name": "Project WikiLoop",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5935335233552384/",
+        "tech": [
+            "mediawiki",
+            "python",
+            "java"
+        ],
+        "cat": "Other",
+        "top": [
+            "knowledge graphs",
+            "computer-assisted translation",
+            "cultural heritage"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3
+        ]
+    },
+    {
+        "name": "React Native Elements",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/4838168020385792/",
+        "tech": [
+            "javascript",
+            "react",
+            "react native"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "ui toolkit",
+            "design system"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2
+        ]
+    },
+    {
+        "name": "Rizin",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5119563070439424/",
+        "tech": [
+            "c",
+            "c++",
+            "qt",
+            "python"
+        ],
+        "cat": "Security",
+        "top": [
+            "reverse engineering",
+            "computer security",
+            "debugging"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3
+        ]
+    },
+    {
+        "name": "Scala Center",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5492555210293248/",
+        "tech": [
+            "#scala",
+            "#scala_lang",
+            "#jvm",
+            "#llvm",
+            "#js"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "#compilers",
+            "#programming-tools",
+            "#functional-programming",
+            "#programming-languages",
+            "#education"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            4
+        ]
+    },
+    {
+        "name": "Shaka Player",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/4852309401534464/",
+        "tech": [
+            "javascript",
+            "python",
+            "ui/ux",
+            "video codecs",
+            "web development"
+        ],
+        "cat": "Graphics / Video / Audio / Virtual Reality",
+        "top": [
+            "web",
+            "video",
+            "streaming"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2
+        ]
+    },
+    {
+        "name": "TARDIS SN",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/4742904236474368/",
+        "tech": [
+            "python",
+            "jupyter",
+            "numba",
+            "pandas",
+            "numpy"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "astrophysics",
+            "simulation",
+            "visualization",
+            "big data"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3
+        ]
+    },
+    {
+        "name": "Tarantool",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6336686404927488/",
+        "tech": [
+            "c",
+            "lua",
+            "sql"
+        ],
+        "cat": "Data and Databases",
+        "top": [
+            "high performance data processing",
+            "in-memory data grid",
+            "algorithms",
+            "distributed systems"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3
+        ]
+    },
+    {
+        "name": "The ENIGMA Team",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5988826467532800/",
+        "tech": [
+            "c++",
+            "opengl",
+            "qt5",
+            "android"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "game development",
+            "programming",
+            "game design",
+            "compiler",
+            "graphics"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2
+        ]
+    },
+    {
+        "name": "The Palisadoes Foundation",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/4835102856577024/",
+        "tech": [
+            "flutter",
+            "mongodb",
+            "node.js",
+            "graphql",
+            "javascript"
+        ],
+        "cat": "Social / Communications",
+        "top": [
+            "mobile apps",
+            "web development",
+            "cloud computing",
+            "social impact",
+            "social good"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            5
+        ]
+    },
+    {
+        "name": "The R Project for Statistical Computing",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6564346347388928/",
+        "tech": [
+            "r-project",
+            "c/c++",
+            "fortran",
+            "javascript"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "data science",
+            "visualization",
+            "statistics",
+            "graphics",
+            "machine learning"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            21
+        ]
+    },
+    {
+        "name": "TianoCore",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6228850043781120/",
+        "tech": [
+            "uefi",
+            "c",
+            "python",
+            "rust",
+            "golang"
+        ],
+        "cat": "Operating Systems",
+        "top": [
+            "uefi",
+            "bootloader",
+            "edk2",
+            "firmware",
+            "open system firmware"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            5
+        ]
+    },
+    {
+        "name": "Xfce",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5706869816950784/",
+        "tech": [
+            "gtk",
+            "c",
+            "python",
+            "vala",
+            "javascript"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "desktop environment",
+            "gui"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2
+        ]
+    },
+    {
+        "name": "Xiph.Org Foundation",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5197456597319680/",
+        "tech": [
+            "rust",
+            "c language",
+            "assembly",
+            "x86",
+            "arm"
+        ],
+        "cat": "Graphics / Video / Audio / Virtual Reality",
+        "top": [
+            "video encode",
+            "video decode",
+            "multimedia",
+            "video"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6438212253253632/",
+        "name": "afl++",
+        "tech": [
+            "fuzzing",
+            "c/c++",
+            "qemu",
+            "llvm",
+            "sanitizers"
+        ],
+        "cat": "Security",
+        "top": [
+            "bug finding",
+            "software testing",
+            "fuzzing"
+        ],
+        "year": [
+            2020
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5480514170912768/",
+        "name": "Amahi",
+        "tech": [
+            "ruby on rails",
+            "javascript",
+            "android",
+            "golang",
+            "swift"
+        ],
+        "cat": "Operating Systems",
+        "top": [
+            "operating systems",
+            " networking",
+            " web servers",
+            "streaming",
+            "mobile-apps"
+        ],
+        "year": [
+            2020,
+            2019,
+            2018,
+            2017,
+            2014
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            0,
+            0,
+            3,
+            5,
+            7,
+            3,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5995132419047424/",
+        "name": "Android Graphics Tools Team",
+        "tech": [
+            "vulkan",
+            "opengl",
+            "c/c++",
+            "java",
+            "python 3",
+            "c++",
+            "spir-v",
+            "webgpu"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "developer tools",
+            "2d/3d graphics",
+            "debugging",
+            "profiling",
+            "bug finding",
+            "fuzzing",
+            "graphics"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            3,
+            3
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5270382996619264/",
+        "name": "AnitaB.org Open Source",
+        "tech": [
+            "ios",
+            "android",
+            "python",
+            "javascript"
+        ],
+        "cat": "Other",
+        "top": [
+            "mobile",
+            " web",
+            "mobile programming",
+            "web programming"
+        ],
+        "year": [
+            2020
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            4,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5135086290206720/",
+        "name": "AOSSIE",
+        "tech": [
+            "javascript",
+            "swift",
+            "kotlin",
+            "python",
+            "scala",
+            "machine learning",
+            "android",
+            "ios"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "electronic voting",
+            "natural language processing",
+            "machine learning",
+            "environment",
+            "social science"
+        ],
+        "year": [
+            2021,
+            2020
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            9,
+            11
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5702681049432064/",
+        "name": "Apertium",
+        "tech": [
+            "c++",
+            "bash",
+            "python",
+            "xml",
+            "javascript"
+        ],
+        "cat": "Other",
+        "top": [
+            "machine translation",
+            "natural language processing",
+            "less-resourced languages"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017,
+            2014,
+            2013,
+            2012,
+            2011,
+            2010
+        ],
+        "project": [
+            0,
+            8,
+            9,
+            10,
+            10,
+            15,
+            0,
+            0,
+            10,
+            11,
+            10,
+            7,
+            10
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5659873647263744/",
+        "name": "apertus\u00b0 Association",
+        "tech": [
+            "fpga",
+            "vhdl",
+            "c/c++",
+            "linux",
+            "embedded"
+        ],
+        "cat": "Graphics / Video / Audio / Virtual Reality",
+        "top": [
+            "camera",
+            "vision",
+            "computational photography",
+            "image processing",
+            "digital imaging",
+            "computer vision"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            4,
+            4,
+            5
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5459614121852928/",
+        "name": "appleseed",
+        "tech": [
+            "c++11",
+            "python",
+            "opengl"
+        ],
+        "cat": "Graphics / Video / Audio / Virtual Reality",
+        "top": [
+            "computer graphics",
+            "image synthesis",
+            "rendering",
+            "animation",
+            "simulation"
+        ],
+        "year": [
+            2020,
+            2014
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6264664972853248/",
+        "name": "Arduino",
+        "tech": [
+            "arduino",
+            "golang",
+            "c/c++"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "electronics",
+            " robotics",
+            "interactivity"
+        ],
+        "year": [
+            2020
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/4848051277004800/",
+        "name": "ArduPilot",
+        "tech": [
+            "drones",
+            "python",
+            "robotics",
+            "linux",
+            "c/c++"
+        ],
+        "cat": "Other",
+        "top": [
+            "vision",
+            "robotics",
+            "embedded systems",
+            "real-time os",
+            "drones",
+            "vison",
+            "real-time"
+        ],
+        "year": [
+            2021,
+            2020,
+            2018,
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            5,
+            0,
+            5,
+            3
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5073969981423616/",
+        "name": "BeagleBoard.org",
+        "tech": [
+            "linux",
+            "tensorflow",
+            "python",
+            "javascript",
+            "opencv"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "robotics",
+            "iot",
+            "teaching",
+            "real-time",
+            "embedded"
+        ],
+        "year": [
+            2020,
+            2019,
+            2016,
+            2015,
+            2014,
+            2013,
+            2010
+        ],
+        "project": [
+            0,
+            6,
+            0,
+            0,
+            6,
+            6,
+            7,
+            6,
+            0,
+            0,
+            3,
+            4,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6683736474648576/",
+        "name": "BioGears",
+        "tech": [
+            "c++11",
+            "c/c++",
+            "python",
+            "cmake"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "physiology",
+            "pharmacological modeling",
+            "computational biology",
+            "mathematical software"
+        ],
+        "year": [
+            2020
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5672605809377280/",
+        "name": "Blender Foundation",
+        "tech": [
+            "c",
+            "c++",
+            "python",
+            "opengl",
+            "vulkan"
+        ],
+        "cat": "Graphics / Video / Audio / Virtual Reality",
+        "top": [
+            "3d",
+            "graphics",
+            "virtual reality",
+            "animation",
+            "artist tools",
+            "3d tools",
+            "rendering",
+            "3d animation"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017,
+            2016,
+            2014,
+            2013,
+            2012,
+            2011,
+            2010,
+            2009
+        ],
+        "project": [
+            6,
+            10,
+            15,
+            13,
+            12,
+            7,
+            0,
+            8,
+            5,
+            5,
+            7,
+            9,
+            8
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6585514028695552/",
+        "name": "Boost C++",
+        "tech": [
+            "c++17",
+            "c++11",
+            "c++"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "programming libraries",
+            "c++",
+            "peer-reviewed libraries",
+            "c++ standard"
+        ],
+        "year": [
+            2020,
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            11,
+            9,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5647022668906496/",
+        "name": "BRL-CAD",
+        "tech": [
+            "opencl",
+            "c/c++",
+            "python",
+            "tcl/tk",
+            "opengl",
+            "scripting"
+        ],
+        "cat": "Graphics / Video / Audio / Virtual Reality",
+        "top": [
+            "data visualization",
+            "3d cad geometry",
+            "ray tracing",
+            "solid modeling",
+            "real-time computer graphics",
+            "geometry",
+            "visualization",
+            "2d/3d graphics",
+            "high performance computing"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017,
+            2016,
+            2015,
+            2014,
+            2013,
+            2012,
+            2011,
+            2009
+        ],
+        "project": [
+            3,
+            0,
+            2,
+            7,
+            7,
+            10,
+            9,
+            9,
+            8,
+            7,
+            8,
+            8,
+            6
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5372385280131072/",
+        "name": "caMicroscope",
+        "tech": [
+            "javascript",
+            "python",
+            "java",
+            "medical imaging",
+            "tensorflow",
+            "mongodb"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "science and medicine",
+            " data integration",
+            " distributed systems",
+            " cloud",
+            " precision medicine",
+            "data integration",
+            "machine learning",
+            "distributed systems"
+        ],
+        "year": [
+            2021,
+            2020
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            5
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5106421244362752/",
+        "name": "Canadian Centre for Computational Genomics",
+        "tech": [
+            "python",
+            "r-project",
+            "javascript",
+            "react",
+            "nodejs"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "bioinformatics",
+            "data science",
+            "visualization",
+            "statistics",
+            "web development"
+        ],
+        "year": [
+            2020,
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            0,
+            5,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6199282348064768/",
+        "name": "Casbin",
+        "tech": [
+            "go",
+            "javascript",
+            "react",
+            "rust",
+            "python",
+            "golang",
+            "java",
+            "nodejs"
+        ],
+        "cat": "Security",
+        "top": [
+            "security",
+            "front-end",
+            "web",
+            "cloud",
+            "authorization"
+        ],
+        "year": [
+            2021,
+            2020
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            9
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5707287336845312/",
+        "name": "Catrobat",
+        "tech": [
+            "java",
+            "android",
+            "swift",
+            "ios",
+            "php"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "visual programming",
+            "app development",
+            "gaming",
+            "creativity tools",
+            "education"
+        ],
+        "year": [
+            2020,
+            2019,
+            2018,
+            2017,
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            7,
+            5,
+            5,
+            9,
+            12,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5102272740065280/",
+        "name": "CCExtractor Development",
+        "tech": [
+            "c",
+            "python",
+            "ml",
+            "flutter",
+            "rust"
+        ],
+        "cat": "Graphics / Video / Audio / Virtual Reality",
+        "top": [
+            "vision",
+            "ai",
+            "media",
+            "linux",
+            "bittorrent",
+            "video",
+            "subtitles"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017,
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            6,
+            6,
+            6,
+            10,
+            8,
+            9
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6273779027673088/",
+        "name": "Ceph Foundation",
+        "tech": [
+            "c/c++",
+            "jenkins",
+            "python",
+            "javascript",
+            "shell script"
+        ],
+        "cat": "Other",
+        "top": [
+            " distributed systems",
+            "software defined storage"
+        ],
+        "year": [
+            2020
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            4,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6240588592054272/",
+        "name": "CERN-HSF",
+        "tech": [
+            "c/c++",
+            "python",
+            "data analysis",
+            "machine learning",
+            "concurrency",
+            "container orchestration"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "big data",
+            "machine learning",
+            "performance optimization",
+            "algorithmics",
+            "particle physics",
+            "big data science"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            20,
+            26,
+            29,
+            34,
+            25
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6538937723518976/",
+        "name": "CGAL Project",
+        "tech": [
+            "c++",
+            "git",
+            "qt",
+            "c/c++"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "computational geometry",
+            "geometry processing",
+            "mesh processing",
+            "triangulation",
+            "arrangement",
+            "computation geometry",
+            "geometry"
+        ],
+        "year": [
+            2021,
+            2020,
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            7,
+            0,
+            7,
+            5
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6232321151205376/",
+        "name": "CHAOSS",
+        "tech": [
+            "python",
+            "javascript",
+            "kibana",
+            "elasticsearch",
+            "mysql"
+        ],
+        "cat": "Other",
+        "top": [
+            "community health",
+            "analytics"
+        ],
+        "year": [
+            2020,
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            4,
+            9,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6086891878744064/",
+        "name": "Chapel",
+        "tech": [
+            "chapel",
+            "high performance computing",
+            "c",
+            "c++",
+            "python"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "programming languages",
+            "compilers",
+            "high performance computing",
+            "distributed computing",
+            "parallel computing"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2017,
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            3,
+            0,
+            4,
+            4,
+            3
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5983189996142592/",
+        "name": "Checker Framework",
+        "tech": [
+            "java"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "programmer productivity",
+            "software engineering",
+            "verification",
+            "bug finding",
+            "type systems"
+        ],
+        "year": [
+            2020,
+            2019,
+            2018,
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            5,
+            3,
+            5,
+            2,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/4766383010742272/",
+        "name": "Checkstyle",
+        "tech": [
+            "java",
+            "antlr",
+            "xpath"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "static code analysis\u200e",
+            "code review tool",
+            "coding standards",
+            "coding conventions",
+            "static code analysis"
+        ],
+        "year": [
+            2021,
+            2020,
+            2017,
+            2014
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            0,
+            0,
+            5,
+            0,
+            0,
+            3,
+            2
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6293580166987776/",
+        "name": "CircuitVerse.org",
+        "tech": [
+            "rails",
+            "javascript",
+            "bootstrap",
+            "html5",
+            "canvas",
+            "machine learning",
+            "internationalization"
+        ],
+        "cat": "Web",
+        "top": [
+            "web",
+            "simulations",
+            "pedagogy",
+            "education",
+            "digital logic design"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            4,
+            6
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4923749205278720/",
+        "name": "CiviCRM",
+        "tech": [
+            "php",
+            "javascript",
+            "angularjs",
+            "mysql"
+        ],
+        "cat": "Data and Databases",
+        "top": [
+            "crm",
+            "nonprofits"
+        ],
+        "year": [
+            2020,
+            2019,
+            2016,
+            2015,
+            2014
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            5,
+            8,
+            8,
+            0,
+            0,
+            2,
+            4,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5861737481371648/",
+        "name": "Cloud Native Computing Foundation (CNCF)",
+        "tech": [
+            "kubernetes",
+            "golang",
+            "cloud",
+            "rust",
+            "service mesh"
+        ],
+        "cat": "Cloud",
+        "top": [
+            "cloud",
+            " web",
+            "devops",
+            "kubernetes",
+            "service mesh"
+        ],
+        "year": [
+            2020,
+            2019,
+            2018,
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            6,
+            7,
+            15,
+            17,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5332159690178560/",
+        "name": "CloudCV",
+        "tech": [
+            "python",
+            "django",
+            "aws",
+            "docker",
+            "docker",
+            "angular"
+        ],
+        "cat": "Cloud",
+        "top": [
+            "machine learning",
+            "artificial intelligence",
+            "deep learning",
+            "computer vision",
+            "reinforcement learning"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017,
+            2016,
+            2015
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            2,
+            4,
+            5,
+            4,
+            3,
+            3
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5349298455183360/",
+        "name": "Continuous Delivery Foundation",
+        "tech": [
+            "tekton",
+            "spinnaker",
+            "ci/cd",
+            "screwdriver",
+            "jenkins",
+            "ortelius",
+            "screwdriver.cd"
+        ],
+        "cat": "Cloud",
+        "top": [
+            "continuous delivery",
+            "continuous integration",
+            "cloud",
+            "devops",
+            "great developer tooling",
+            "developer tools"
+        ],
+        "year": [
+            2021,
+            2020
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            6
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5721709165936640/",
+        "name": "coreboot",
+        "tech": [
+            "c",
+            "assembly",
+            "x86",
+            "arm"
+        ],
+        "cat": "Operating Systems",
+        "top": [
+            "firmware",
+            "boot loader",
+            "drivers",
+            "hardware"
+        ],
+        "year": [
+            2020,
+            2019,
+            2016,
+            2015,
+            2014,
+            2013,
+            2011,
+            2010,
+            2009
+        ],
+        "project": [
+            3,
+            5,
+            4,
+            0,
+            4,
+            3,
+            2,
+            3,
+            0,
+            0,
+            3,
+            2,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5450793232105472/",
+        "name": "Creative Commons",
+        "tech": [
+            "javascript",
+            "vue.js",
+            "python",
+            "django",
+            "wordpress"
+        ],
+        "cat": "Web",
+        "top": [
+            "copyleft",
+            "web",
+            "creative commons",
+            "legal",
+            "nonprofits"
+        ],
+        "year": [
+            2020,
+            2019,
+            2013,
+            2012,
+            2010,
+            2009
+        ],
+        "project": [
+            2,
+            3,
+            0,
+            1,
+            2,
+            0,
+            0,
+            0,
+            0,
+            0,
+            5,
+            5,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5396163661922304/",
+        "name": "CRIU",
+        "tech": [
+            "linux",
+            "c",
+            "assembly",
+            "linux kernel",
+            "python"
+        ],
+        "cat": "Operating Systems",
+        "top": [
+            " cloud",
+            "live migration",
+            "snapshots",
+            "containers",
+            "operating systems",
+            "checkpoint-restore"
+        ],
+        "year": [
+            2021,
+            2020
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            3
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5679162177617920/",
+        "name": "Cuneiform Digital Library Initiative (CDLI)",
+        "tech": [
+            "python 3",
+            "php",
+            "mysql",
+            "html",
+            "css",
+            "python",
+            "javascript",
+            "java"
+        ],
+        "cat": "Data and Databases",
+        "top": [
+            "computational linguistics",
+            "web portal",
+            "data processing",
+            "data visualization",
+            "digitization",
+            "cultural heritage",
+            "nlp"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            5,
+            9,
+            7
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6522063568764928/",
+        "name": "Dart",
+        "tech": [
+            "dart",
+            "flutter",
+            "programming-language"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "mobile-apps",
+            "mobile apps"
+        ],
+        "year": [
+            2021,
+            2020
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            5,
+            3
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/4709350374899712/",
+        "name": "DBpedia",
+        "tech": [
+            "python",
+            "scala",
+            "java",
+            "javascript",
+            "rdf",
+            "sparql"
+        ],
+        "cat": "Data and Databases",
+        "top": [
+            "knowledge graph",
+            "natural language processing",
+            "semantic web",
+            "data science",
+            "linked data",
+            "knowledge graphs",
+            "data analytics",
+            "data extraction"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            7,
+            3,
+            6,
+            7,
+            10
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5913368723980288/",
+        "name": "Debian",
+        "tech": [
+            "git",
+            "python",
+            "javascript",
+            "c/c++",
+            "irc"
+        ],
+        "cat": "Operating Systems",
+        "top": [
+            "operating systems",
+            " kernel",
+            "package managers",
+            "packaging",
+            "android-sdk",
+            "clojure",
+            "debian-ci"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2009
+        ],
+        "project": [
+            7,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            5,
+            8,
+            5
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5400186335002624/",
+        "name": "Digital Impact Alliance (DIAL) at UN Foundation",
+        "tech": [
+            "c++",
+            "javascript",
+            "android",
+            "php",
+            "python",
+            "linux",
+            "many more"
+        ],
+        "cat": "Other",
+        "top": [
+            "nonprofit",
+            "humanrights",
+            "humanitarian",
+            "international",
+            "global"
+        ],
+        "year": [
+            2021,
+            2020
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            14,
+            12
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6030298738851840/",
+        "name": "Django Software Foundation",
+        "tech": [
+            "python",
+            "django"
+        ],
+        "cat": "Web",
+        "top": [
+            "web development"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017,
+            2016,
+            2014,
+            2013,
+            2012,
+            2011,
+            2010,
+            2009
+        ],
+        "project": [
+            6,
+            2,
+            3,
+            1,
+            3,
+            2,
+            0,
+            1,
+            0,
+            0,
+            2,
+            2,
+            4
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5836893377265664/",
+        "name": "Drupal",
+        "tech": [
+            "php",
+            "symfony",
+            "sql",
+            "javascript",
+            "drupal 8"
+        ],
+        "cat": "Web",
+        "top": [
+            "web development",
+            "cms",
+            "apps",
+            "mobile-apps",
+            "object oriented programming"
+        ],
+        "year": [
+            2020,
+            2019,
+            2018,
+            2017,
+            2016,
+            2015,
+            2014,
+            2012,
+            2011,
+            2010,
+            2009
+        ],
+        "project": [
+            18,
+            18,
+            15,
+            13,
+            0,
+            12,
+            9,
+            9,
+            6,
+            1,
+            2,
+            1,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4711920076062720/",
+        "name": "Eclipse Foundation",
+        "tech": [
+            "eclipsejavaide",
+            "jakartaee",
+            "java",
+            "che",
+            "deep learning"
+        ],
+        "cat": "Other",
+        "top": [
+            "cloud native java",
+            "automotive",
+            "tools",
+            " robotics",
+            "iot & edge"
+        ],
+        "year": [
+            2020,
+            2016,
+            2009
+        ],
+        "project": [
+            19,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            11,
+            0,
+            0,
+            0,
+            7,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4573440532545536/",
+        "name": "Elastic",
+        "tech": [
+            "java",
+            "react",
+            "node.js",
+            "golang"
+        ],
+        "cat": "Data and Databases",
+        "top": [
+            "databases",
+            "search",
+            "security",
+            "observability"
+        ],
+        "year": [
+            2020,
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            2,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4824946267652096/",
+        "name": "Embox",
+        "tech": [
+            "c",
+            "gcc",
+            "assembly"
+        ],
+        "cat": "Operating Systems",
+        "top": [
+            " embedded systems",
+            "rtos"
+        ],
+        "year": [
+            2020
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4857921046839296/",
+        "name": "Erlang Ecosystem Foundation",
+        "tech": [
+            "erlang",
+            "elixir",
+            "lfe",
+            "beam"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "language",
+            "soft real-time",
+            " distributed systems",
+            "messaging",
+            "instant messaging"
+        ],
+        "year": [
+            2020
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6477554824773632/",
+        "name": "Fedora Project",
+        "tech": [
+            "python 3",
+            "rest",
+            "linux",
+            "web development",
+            "linux distribution"
+        ],
+        "cat": "Operating Systems",
+        "top": [
+            "containers",
+            "linux",
+            "distribution",
+            "mobile",
+            "web development"
+        ],
+        "year": [
+            2020,
+            2019,
+            2018,
+            2017,
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            6,
+            5,
+            5,
+            5,
+            4,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6245462977282048/",
+        "name": "FFmpeg",
+        "tech": [
+            "c",
+            "asm",
+            "git",
+            "assembler"
+        ],
+        "cat": "Graphics / Video / Audio / Virtual Reality",
+        "top": [
+            "audio",
+            "video",
+            "subtitles",
+            "multimedia",
+            "images"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017,
+            2016,
+            2015,
+            2010,
+            2009
+        ],
+        "project": [
+            6,
+            7,
+            0,
+            0,
+            0,
+            0,
+            7,
+            7,
+            6,
+            5,
+            6,
+            5,
+            5
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5641437164601344/",
+        "name": "FOSSology",
+        "tech": [
+            "php",
+            "javascript",
+            "c/c++",
+            "twig",
+            "python",
+            "postgresql"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "licensing",
+            "compliance",
+            "spdx",
+            "oss licencing",
+            "license-scan",
+            "license management"
+        ],
+        "year": [
+            2021,
+            2020,
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            3,
+            7
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6046169112772608/",
+        "name": "FrameNet Brasil (UFJF)",
+        "tech": [
+            "php",
+            "mysql",
+            "javascript",
+            "python"
+        ],
+        "cat": "Data and Databases",
+        "top": [
+            "natural language processing",
+            "natural language understanding",
+            "multimodality",
+            " video processing",
+            "multilinguality",
+            "multimodal communication"
+        ],
+        "year": [
+            2021,
+            2020
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            1
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6542389937700864/",
+        "name": "Free and Open Source Silicon Foundation",
+        "tech": [
+            "verilog",
+            "risc-v",
+            "python",
+            "c++",
+            "compiler",
+            "web development",
+            "jenkins"
+        ],
+        "cat": "Other",
+        "top": [
+            "silicon",
+            "eda",
+            "fpga",
+            "hardware",
+            "web services",
+            "debug",
+            "simulation",
+            "electronic design tools"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017,
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            4,
+            6,
+            7,
+            4,
+            11
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5255426173566976/",
+        "name": "FreeBSD Project",
+        "tech": [
+            "c/c++",
+            "llvm",
+            "shell script",
+            "assembly",
+            "make",
+            "c/c+"
+        ],
+        "cat": "Operating Systems",
+        "top": [
+            "operating systems",
+            "virtualization",
+            "kernel",
+            "cloud",
+            "embedded systems"
+        ],
+        "year": [
+            2021,
+            2020
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            6,
+            5
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5483147923292160/",
+        "name": "FreeType",
+        "tech": [
+            "c",
+            "gnu make",
+            "gnu autotools",
+            "python",
+            "fonts"
+        ],
+        "cat": "Graphics / Video / Audio / Virtual Reality",
+        "top": [
+            "graphics",
+            "library",
+            "rendering",
+            "fonts",
+            "opentype",
+            "truetype"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            3,
+            3,
+            1
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5868804143316992/",
+        "name": "FRRouting",
+        "tech": [
+            "c",
+            "linux",
+            "linux kernel",
+            "networking",
+            "lua",
+            "routing"
+        ],
+        "cat": "Other",
+        "top": [
+            " networking",
+            "software defined networking",
+            "linux",
+            "performance",
+            "systems programming",
+            "networking",
+            "routing"
+        ],
+        "year": [
+            2021,
+            2020
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            1
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5791816890187776/",
+        "name": "GDevelop",
+        "tech": [
+            "javascript",
+            "c/c++",
+            "web development",
+            "game development",
+            "react"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "gaming",
+            "graphics",
+            "web applications",
+            " web",
+            "compilers"
+        ],
+        "year": [
+            2020
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/4842426950221824/",
+        "name": "Gentoo Foundation",
+        "tech": [
+            "shell",
+            "bash",
+            "c/c++",
+            "python",
+            "linux"
+        ],
+        "cat": "Operating Systems",
+        "top": [
+            "operating systems",
+            "package management",
+            "embedded",
+            "init",
+            "security",
+            "package",
+            "automation"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017,
+            2016,
+            2014,
+            2013,
+            2012,
+            2011,
+            2010
+        ],
+        "project": [
+            0,
+            16,
+            14,
+            8,
+            6,
+            3,
+            0,
+            5,
+            3,
+            2,
+            2,
+            4,
+            2
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5291444977270784/",
+        "name": "GeomScale",
+        "tech": [
+            "c++",
+            "r",
+            "python",
+            "jupyter",
+            "github-actions"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "mathematical software",
+            "statistics",
+            "biology",
+            "optimization",
+            "finance",
+            "computation geometry",
+            "computational biology",
+            "mathematics",
+            "data science"
+        ],
+        "year": [
+            2021,
+            2020
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            5
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6398200235163648/",
+        "name": "Git",
+        "tech": [
+            "c",
+            "shell script",
+            "git",
+            "c language"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "version control",
+            "dvcs"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017,
+            2016,
+            2015,
+            2014,
+            2012,
+            2011,
+            2010
+        ],
+        "project": [
+            0,
+            3,
+            5,
+            3,
+            0,
+            2,
+            2,
+            1,
+            1,
+            3,
+            2,
+            3,
+            2
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/4716668999172096/",
+        "name": "Global Alliance for Genomics and Health",
+        "tech": [
+            "java",
+            "python",
+            "node.js",
+            "mongodb",
+            "spring",
+            "sql",
+            "hl7 fhir"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "genomics",
+            "genetics",
+            "bioinformatics",
+            "web",
+            "standards",
+            "healthcare",
+            "data security",
+            "cloud",
+            "data discovery"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            4,
+            5,
+            4,
+            7
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4988908019908608/",
+        "name": "GNOME",
+        "tech": [
+            "c",
+            "rust",
+            "gtk",
+            "vala",
+            "python"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "desktop",
+            "games",
+            "applications",
+            "productivity"
+        ],
+        "year": [
+            2020,
+            2019,
+            2018,
+            2017,
+            2016,
+            2015,
+            2014,
+            2013,
+            2012,
+            2010,
+            2009
+        ],
+        "project": [
+            24,
+            20,
+            0,
+            28,
+            29,
+            35,
+            22,
+            18,
+            19,
+            13,
+            8,
+            14,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6204387118022656/",
+        "name": "GNSS-SDR",
+        "tech": [
+            "c++",
+            "gnss",
+            "c++11",
+            "c++14",
+            "c++17",
+            "c++20"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "gnss",
+            "signal processing",
+            "navigation",
+            "software defined radio",
+            "geospatial"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017,
+            2015,
+            2014,
+            2013
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            3,
+            4,
+            6,
+            0,
+            5,
+            5,
+            3,
+            2,
+            1
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5653860256841728/",
+        "name": "GNU Compiler Collection (GCC)",
+        "tech": [
+            "c/c++",
+            "gnu autotools",
+            "gnu make"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "compilers",
+            "toolchain",
+            " developer tools",
+            "openmp",
+            "developer tools",
+            "rust"
+        ],
+        "year": [
+            2021,
+            2020,
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            2,
+            3
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5764694136061952/",
+        "name": "GNU Octave",
+        "tech": [
+            "c++",
+            "hg"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "mathematics",
+            "numerical computation",
+            "numerical methods",
+            "matlab",
+            "scientific computing"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017,
+            2016,
+            2014
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            0,
+            5,
+            4,
+            3,
+            0,
+            1,
+            1
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5786120553496576/",
+        "name": "GNU Radio",
+        "tech": [
+            "python",
+            "c++",
+            "qt"
+        ],
+        "cat": "Other",
+        "top": [
+            "software defined radio",
+            "signal processing",
+            "communication"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017,
+            2016,
+            2014,
+            2013
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            5,
+            4,
+            0,
+            2,
+            2,
+            2,
+            2,
+            1,
+            1
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5744305389436928/",
+        "name": "Godot Engine",
+        "tech": [
+            "c/c++",
+            "opengl",
+            "vulkan",
+            "c/c+",
+            "gdscript"
+        ],
+        "cat": "Graphics / Video / Audio / Virtual Reality",
+        "top": [
+            "graphics",
+            "game development",
+            "cross-platform",
+            "game engines",
+            "virtual reality"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            5,
+            8,
+            6,
+            5
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6028158437949440/",
+        "name": "GPAC",
+        "tech": [
+            "c",
+            "javascript",
+            "opengl"
+        ],
+        "cat": "Graphics / Video / Audio / Virtual Reality",
+        "top": [
+            "multimedia",
+            "streaming",
+            "packaging",
+            "interactivity",
+            "rendering"
+        ],
+        "year": [
+            2020,
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6354766843609088/",
+        "name": "GraphQL Foundation",
+        "tech": [
+            "graphql",
+            "javascript",
+            "react",
+            "node.js"
+        ],
+        "cat": "Data and Databases",
+        "top": [
+            "data and databases",
+            "api",
+            "graphql"
+        ],
+        "year": [
+            2020
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5748009966501888/",
+        "name": "Haiku",
+        "tech": [
+            "c++",
+            "posix",
+            "unix",
+            "webkit",
+            "bsd unix",
+            "virtualization"
+        ],
+        "cat": "Operating Systems",
+        "top": [
+            "filesystem",
+            "network",
+            "virtualization",
+            "kernel",
+            "drivers",
+            "desktop",
+            "media",
+            "graphics",
+            "web"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017,
+            2014,
+            2012,
+            2011,
+            2010,
+            2009
+        ],
+        "project": [
+            5,
+            5,
+            4,
+            5,
+            0,
+            2,
+            0,
+            0,
+            5,
+            2,
+            1,
+            4,
+            3
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6216810210263040/",
+        "name": "Haskell.org",
+        "tech": [
+            "haskell",
+            "ghc",
+            "cabal",
+            "codeworld",
+            "servant",
+            "compiler"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "haskell",
+            "functional programming",
+            " education",
+            "build tools",
+            "compilers",
+            "#functional-programming",
+            "#education",
+            "#compilers",
+            "#programming-languages",
+            "#programming-tools"
+        ],
+        "year": [
+            2021,
+            2020,
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            15,
+            0,
+            12,
+            10
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6487112334966784/",
+        "name": "Hazelcast",
+        "tech": [
+            "java",
+            "distributed systems"
+        ],
+        "cat": "Data and Databases",
+        "top": [
+            "in memory data grid",
+            "data streaming",
+            "stream processing"
+        ],
+        "year": [
+            2020
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6369733965774848/",
+        "name": "Homebrew",
+        "tech": [
+            "ruby",
+            "bash"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "package managers",
+            "package management",
+            "macos",
+            "linux"
+        ],
+        "year": [
+            2020,
+            2018,
+            2017,
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            4,
+            2,
+            1,
+            0,
+            3,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5753537857847296/",
+        "name": "Hydra Ecosystem",
+        "tech": [
+            "python",
+            "rest",
+            "apis",
+            "hydra",
+            "postgresql",
+            "docker",
+            "javascript",
+            "redis"
+        ],
+        "cat": "Web",
+        "top": [
+            "web development",
+            "http",
+            "rest apis",
+            "knowledge graph",
+            "semantic web",
+            "web services",
+            "linked data",
+            "knowledge graphs"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            2,
+            2
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6330511550578688/",
+        "name": "INCF",
+        "tech": [
+            "python",
+            "c/c++",
+            "java",
+            "tensorflow",
+            "javascript"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "neuroscience",
+            "brain modelling",
+            "neuroimage processing",
+            "data visualization",
+            " big data",
+            "neuroimaging",
+            "big data"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            13,
+            16,
+            17,
+            21,
+            21
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5992304050962432/",
+        "name": "Inclusive Design Institute",
+        "tech": [
+            "javascript",
+            "html",
+            "css",
+            "node.js"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "accessibility",
+            "inclusion",
+            "web applications",
+            "web development",
+            "web"
+        ],
+        "year": [
+            2020,
+            2018,
+            2016,
+            2014,
+            2013,
+            2012,
+            2010
+        ],
+        "project": [
+            0,
+            5,
+            0,
+            11,
+            10,
+            6,
+            0,
+            4,
+            0,
+            5,
+            0,
+            2,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5656327346454528/",
+        "name": "Inkscape",
+        "tech": [
+            "c++",
+            "svg",
+            "gtk",
+            "python",
+            "c/c++",
+            "python 3"
+        ],
+        "cat": "Graphics / Video / Audio / Virtual Reality",
+        "top": [
+            "graphics",
+            "web",
+            "geometry",
+            "vector graphics",
+            "design"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017,
+            2016,
+            2014,
+            2013,
+            2012,
+            2011,
+            2010,
+            2009
+        ],
+        "project": [
+            4,
+            2,
+            3,
+            3,
+            5,
+            2,
+            0,
+            2,
+            2,
+            0,
+            1,
+            3,
+            6
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5820969215590400/",
+        "name": "Intel Media And Audio For Linux",
+        "tech": [
+            "ffmpeg",
+            "gstreamer",
+            "sound open firmware",
+            "libxcam",
+            "vaapi"
+        ],
+        "cat": "Graphics / Video / Audio / Virtual Reality",
+        "top": [
+            "360 stereo video",
+            "opensource audio firmware",
+            "ffmpeg neuronetwork"
+        ],
+        "year": [
+            2020,
+            2019,
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            2,
+            2,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6193723385315328/",
+        "name": "Internet Archive",
+        "tech": [
+            "javascript",
+            "python",
+            "hadoop",
+            "elasticsearch",
+            "golang"
+        ],
+        "cat": "Web",
+        "top": [
+            "web archving",
+            "library",
+            "books",
+            "archiving"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            5,
+            2,
+            3,
+            2
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5722851356704768/",
+        "name": "JBoss Community",
+        "tech": [
+            "java",
+            "golang",
+            "react",
+            "rust",
+            "kubernetes",
+            "node.js"
+        ],
+        "cat": "Web",
+        "top": [
+            "programming languages and development tools",
+            "cloud",
+            "database",
+            "kubernetes",
+            "aerogear",
+            "iot",
+            "machine learning",
+            "messaging",
+            "cfc"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017,
+            2016,
+            2015,
+            2014,
+            2013,
+            2012
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            8,
+            6,
+            5,
+            10,
+            9,
+            3,
+            3,
+            8,
+            10,
+            10
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5743038910955520/",
+        "name": "JdeRobot - Universidad Rey Juan Carlos",
+        "tech": [
+            "ros",
+            "gazebo",
+            "python",
+            "c/c++",
+            "opencv",
+            "tensorflow"
+        ],
+        "cat": "Other",
+        "top": [
+            "robotics",
+            " education",
+            " computer vision",
+            "developer tools",
+            "education",
+            "computer vision",
+            "artificial intelligence"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017,
+            2015
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            0,
+            4,
+            5,
+            6,
+            5,
+            6
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5087283272744960/",
+        "name": "Jenkins project",
+        "tech": [
+            "java",
+            "javascript",
+            "docker",
+            "kubernetes",
+            "go"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "continuous integration",
+            "continuous delivery",
+            "developer tools",
+            "devops",
+            "automation"
+        ],
+        "year": [
+            2020,
+            2019,
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            5,
+            7,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6548330145906688/",
+        "name": "Joplin",
+        "tech": [
+            "node.js",
+            "electron",
+            "react native",
+            "terminal-kit",
+            "react",
+            "javascript"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "notes",
+            "synchronisation",
+            "sharing",
+            "encryption",
+            "cross-platform"
+        ],
+        "year": [
+            2021,
+            2020
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            5
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5566516864483328/",
+        "name": "Kapitan",
+        "tech": [
+            "kubernetes",
+            "jsonnet",
+            "python 3",
+            "jinja2",
+            "terraform"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "programming languages",
+            "great developer tooling",
+            " cloud",
+            "kubernetes"
+        ],
+        "year": [
+            2020,
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            1,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/4834047200591872/",
+        "name": "KDE Community",
+        "tech": [
+            "c++",
+            "qt",
+            "c",
+            "opencv",
+            "qml",
+            "data structures",
+            "opengl"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "vr",
+            "graphics",
+            "applications",
+            "education",
+            "science",
+            "art"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            17,
+            22,
+            19,
+            15
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6595970359361536/",
+        "name": "Kiwix",
+        "tech": [
+            "python 3",
+            "c/c++",
+            "javascript",
+            "node.js",
+            "kotlin",
+            "python",
+            "typescript",
+            "nodejs"
+        ],
+        "cat": "Web",
+        "top": [
+            "offline access"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            2,
+            3,
+            3
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6555254004383744/",
+        "name": "Kodi Foundation",
+        "tech": [
+            "ffmpeg",
+            "python",
+            "c++",
+            "sqlite",
+            "mysql"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "media",
+            "video",
+            "audio",
+            "games"
+        ],
+        "year": [
+            2020,
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            3,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5374310232883200/",
+        "name": "Kubeflow",
+        "tech": [
+            "python",
+            "jupyter notebook",
+            "tensorflow",
+            "kustomize",
+            "kubernetes"
+        ],
+        "cat": "Cloud",
+        "top": [
+            "machine learning",
+            "infrastructure",
+            "cloud",
+            "kubernetes"
+        ],
+        "year": [
+            2020
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5651367128989696/",
+        "name": "LabLua",
+        "tech": [
+            "lua",
+            "c\u00e9u",
+            "lunatik",
+            "pallene",
+            "kernel"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "scripting languages",
+            "reactive programming",
+            "compilers",
+            "operating systems",
+            "reactive languages"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017,
+            2016,
+            2015,
+            2014
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            4,
+            6,
+            8,
+            6,
+            5,
+            5,
+            6,
+            4
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5144401537400832/",
+        "name": "Libre Space Foundation",
+        "tech": [
+            "python",
+            "django",
+            "sdr",
+            "embedded",
+            "space applications",
+            "embedded systems",
+            "machine learning"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "space applications",
+            "spacecraft",
+            "space standards",
+            "satellite data",
+            "orbital dynamics"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            2,
+            3
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6009541631672320/",
+        "name": "LibreHealth",
+        "tech": [
+            "java",
+            "javascript",
+            "python 3",
+            "android",
+            "php",
+            "python"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "web",
+            "radiology",
+            "mobile-apps",
+            "information security",
+            "deep learning",
+            "mobile apps"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            4,
+            9,
+            0,
+            4,
+            5
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/4920197969870848/",
+        "name": "LibreOffice",
+        "tech": [
+            "c++",
+            "python",
+            "java"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "office suite",
+            " end-user application",
+            "desktop application",
+            "android",
+            "end user application"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017,
+            2016,
+            2015,
+            2014,
+            2013,
+            2012,
+            2011
+        ],
+        "project": [
+            0,
+            0,
+            7,
+            9,
+            11,
+            10,
+            10,
+            9,
+            9,
+            7,
+            6,
+            6,
+            7
+        ]
+    },
+    {
+        "name": "gVisor",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5119642997096448/",
+        "tech": [
+            "golang",
+            "linux",
+            "posix",
+            "c/c++"
+        ],
+        "cat": "Operating Systems",
+        "top": [
+            "containers",
+            "sandbox",
+            "virtualization",
+            "kernel"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1
+        ]
+    },
+    {
+        "name": "libcamera",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5084072715485184/",
+        "tech": [
+            "c/c++",
+            "qt5",
+            "gstreamer",
+            "v4l2",
+            "linux kernel"
+        ],
+        "cat": "Graphics / Video / Audio / Virtual Reality",
+        "top": [
+            "camera",
+            "image processing"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/4791907464511488/",
+        "name": "libvirt",
+        "tech": [
+            "kvm",
+            "xen",
+            "hypervisor",
+            "c",
+            "python"
+        ],
+        "cat": "Cloud",
+        "top": [
+            "virtualization",
+            "library"
+        ],
+        "year": [
+            2021,
+            2020,
+            2018,
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            2,
+            0,
+            4,
+            1
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6500210139725824/",
+        "name": "Linkerd",
+        "tech": [
+            "linkerd",
+            "kubernetes",
+            "golang",
+            "rust"
+        ],
+        "cat": "Cloud",
+        "top": [
+            "service mesh",
+            "cloud infrastructure",
+            "microservices",
+            "containers",
+            " networking"
+        ],
+        "year": [
+            2020,
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            2,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5964067927228416/",
+        "name": "Liquid Galaxy project",
+        "tech": [
+            "python",
+            "vue",
+            "html",
+            "javascript",
+            "java",
+            "android",
+            "machinelearning",
+            "arduino"
+        ],
+        "cat": "Graphics / Video / Audio / Virtual Reality",
+        "top": [
+            "maps",
+            "machine learning",
+            "graphics",
+            "visualization",
+            "data visualization",
+            "cluster",
+            "linux",
+            "google earth"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            7,
+            8,
+            11
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6088258989064192/",
+        "name": "lowRISC",
+        "tech": [
+            "systemverilog",
+            "c++",
+            "fpga",
+            "python",
+            "risc-v"
+        ],
+        "cat": "Other",
+        "top": [
+            "open hardware",
+            "compilers"
+        ],
+        "year": [
+            2020,
+            2017,
+            2016,
+            2015
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            4,
+            4,
+            0,
+            0,
+            2,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4588406077652992/",
+        "name": "MacPorts",
+        "tech": [
+            "tcl",
+            "c",
+            "python",
+            "scripting",
+            "buildbot"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "package management",
+            "macos",
+            "build tools",
+            "libraries"
+        ],
+        "year": [
+            2020,
+            2019,
+            2013
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            4,
+            1,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6249801833775104/",
+        "name": "MariaDB Foundation",
+        "tech": [
+            "mariadb",
+            "mysql",
+            "c",
+            "c++",
+            "java",
+            "python"
+        ],
+        "cat": "Data and Databases",
+        "top": [
+            "databases",
+            "sql",
+            "performance",
+            " distributed systems",
+            "distributed systems",
+            "cloud"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            4,
+            2,
+            4
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6400769936326656/",
+        "name": "Matrix",
+        "tech": [
+            "python",
+            "javascript",
+            "rust",
+            "go",
+            "react"
+        ],
+        "cat": "Social / Communications",
+        "top": [
+            "encryption",
+            "realtime communication",
+            "decentralised",
+            "team chat",
+            "chat"
+        ],
+        "year": [
+            2020
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            6,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/4862926560690176/",
+        "name": "MBDyn",
+        "tech": [
+            "c++",
+            "python",
+            "c/c++"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "mechanical engineering",
+            "aeronautics",
+            "automotive",
+            "multibody dynamics",
+            "scientific computing",
+            "computational mechanics",
+            "simulation",
+            "aeroelasticity",
+            "multiphysics"
+        ],
+        "year": [
+            2021,
+            2020,
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            0,
+            1,
+            2
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/4692476220145664/",
+        "name": "MDAnalysis",
+        "tech": [
+            "python",
+            "cython",
+            "numpy",
+            "c/c++"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "biophysics",
+            "computational chemistry",
+            "molecular simulation",
+            "cheminformatics",
+            "molecular dynamics",
+            "simulation",
+            "trajectory analysis",
+            "soft matter physics",
+            "materials",
+            "biochemistry"
+        ],
+        "year": [
+            2021,
+            2020
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            2
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5387896221073408/",
+        "name": "MetaBrainz Foundation Inc.",
+        "tech": [
+            "python",
+            "postgres",
+            "solr",
+            "perl",
+            "spark"
+        ],
+        "cat": "Data and Databases",
+        "top": [
+            "music",
+            "books",
+            "metadata",
+            "community",
+            "open data"
+        ],
+        "year": [
+            2020,
+            2018,
+            2017,
+            2015,
+            2014,
+            2013,
+            2012,
+            2011,
+            2010
+        ],
+        "project": [
+            0,
+            3,
+            2,
+            4,
+            3,
+            5,
+            4,
+            0,
+            5,
+            5,
+            0,
+            7,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/4728495023849472/",
+        "name": "Metasploit",
+        "tech": [
+            "ruby",
+            "postgresql",
+            "python",
+            "c",
+            "assembly"
+        ],
+        "cat": "Security",
+        "top": [
+            "security",
+            "penetration testing",
+            "offensive security",
+            "exploitation"
+        ],
+        "year": [
+            2021,
+            2020,
+            2018,
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            5,
+            0,
+            2,
+            1
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5759703384064000/",
+        "name": "MGGG Redistricting Lab",
+        "tech": [
+            "python",
+            "javascript",
+            "gis",
+            "julia",
+            "mapping",
+            "statistics"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "web-interface",
+            "statistics",
+            "graph algorithms",
+            "mapping",
+            "civic tech",
+            "mapping and surveying"
+        ],
+        "year": [
+            2021,
+            2020
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            1
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5354857417932800/",
+        "name": "MIT App Inventor",
+        "tech": [
+            "javascript",
+            "java",
+            "google web toolkit",
+            "android",
+            "junit",
+            "gwt"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "education",
+            "mobile",
+            "web",
+            "apps",
+            "development"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            4,
+            0,
+            4,
+            6,
+            5
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5847122345197568/",
+        "name": "Mixxx",
+        "tech": [
+            "c++",
+            "qt",
+            "javascript",
+            "deep learning"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "music",
+            "dj",
+            "streaming",
+            "music information retrieval"
+        ],
+        "year": [
+            2020,
+            2011
+        ],
+        "project": [
+            0,
+            0,
+            3,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5101022367711232/",
+        "name": "mlpack",
+        "tech": [
+            "c++",
+            "python",
+            "templates",
+            "machine learning",
+            "deep learning",
+            "openmp"
+        ],
+        "cat": "Data and Databases",
+        "top": [
+            "machine learning",
+            "optimization",
+            "data science",
+            "neighbor-search",
+            "reinforcement learning",
+            "deep learning",
+            "linear algebra"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            10,
+            6,
+            9,
+            8,
+            8
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5420871000260608/",
+        "name": "Moira",
+        "tech": [
+            "golang",
+            "javascript",
+            "typescript",
+            "graphite",
+            "react"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "devops",
+            "monitoring",
+            "alerting",
+            "devtools",
+            "sre"
+        ],
+        "year": [
+            2020,
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            2,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5449155236855808/",
+        "name": "MoveIt",
+        "tech": [
+            "c++",
+            "ros",
+            "c/c++",
+            "python 3",
+            "robotics"
+        ],
+        "cat": "Other",
+        "top": [
+            "robotics"
+        ],
+        "year": [
+            2021,
+            2020
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            1
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5169365365817344/",
+        "name": "Mozilla",
+        "tech": [
+            "javascript",
+            "rust",
+            "html5",
+            "web development",
+            "python"
+        ],
+        "cat": "Web",
+        "top": [
+            "web browser",
+            "devtools",
+            "information security",
+            "open source"
+        ],
+        "year": [
+            2020,
+            2019,
+            2018,
+            2017,
+            2016,
+            2014,
+            2013,
+            2012,
+            2011,
+            2010
+        ],
+        "project": [
+            0,
+            10,
+            11,
+            16,
+            20,
+            25,
+            0,
+            13,
+            21,
+            16,
+            14,
+            11,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5844642704130048/",
+        "name": "MuseScore",
+        "tech": [
+            "c++",
+            "qt",
+            "qml",
+            "cmake"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "music",
+            "notation software",
+            "piano",
+            "guitar",
+            "notation",
+            "audio",
+            "engraving"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017,
+            2016,
+            2014,
+            2013
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            2,
+            5,
+            0,
+            3,
+            3,
+            3,
+            4,
+            3,
+            3
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/4693309712236544/",
+        "name": "mypy",
+        "tech": [
+            "python"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "static code analysis\u00e2\u20ac\u017d",
+            "compiler",
+            "compilers"
+        ],
+        "year": [
+            2021,
+            2020
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            2
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6328123651522560/",
+        "name": "MZmine",
+        "tech": [
+            "java",
+            "javafx"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "mass spectrometry",
+            "molecular analysis",
+            "visualization",
+            "data processing",
+            "molecular networking"
+        ],
+        "year": [
+            2020
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/4898028657311744/",
+        "name": "National Resource for Network Biology (NRNB)",
+        "tech": [
+            "java",
+            "javascript",
+            "python",
+            "r",
+            "rest",
+            "xml"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "network biology",
+            "graphics",
+            "web application",
+            "scientific computing",
+            "data science"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017,
+            2016,
+            2014,
+            2013,
+            2012
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            16,
+            14,
+            17,
+            0,
+            15,
+            20,
+            10,
+            11,
+            15,
+            13
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6636241820319744/",
+        "name": "Neovim",
+        "tech": [
+            "c",
+            "lua",
+            "rpc"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "editor",
+            "programming"
+        ],
+        "year": [
+            2020,
+            2019,
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            2,
+            1,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5983819074633728/",
+        "name": "Netty",
+        "tech": [
+            "java",
+            "jni",
+            "c"
+        ],
+        "cat": "Web",
+        "top": [
+            "nonblocking",
+            "network",
+            "async"
+        ],
+        "year": [
+            2020
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6176584620310528/",
+        "name": "NumFOCUS",
+        "tech": [
+            "python",
+            "c/c++",
+            "javascript",
+            "r",
+            "julia"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "scientific computing",
+            "graphics",
+            "data science",
+            "numerical computing",
+            "numerical computation"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017,
+            2016,
+            2015
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            7,
+            10,
+            40,
+            19,
+            28,
+            45
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5653128168341504/",
+        "name": "NV Access",
+        "tech": [
+            "python",
+            "c++",
+            "ui automation",
+            "iaccessible2",
+            "win32 api"
+        ],
+        "cat": "Other",
+        "top": [
+            "accessibility",
+            " blindness",
+            " screen reader",
+            " braille",
+            " text to speech"
+        ],
+        "year": [
+            2020,
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            1,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4595548239167488/",
+        "name": "Open Bioinformatics Foundation (OBF)",
+        "tech": [
+            "python",
+            "javascript",
+            "c/c++"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "bioinformatics",
+            "computational biology"
+        ],
+        "year": [
+            2020
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            8,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5838773731983360/",
+        "name": "Open Chemistry",
+        "tech": [
+            "c/c++",
+            "python",
+            "javascript",
+            "opengl",
+            "html",
+            "c++14",
+            "c++17"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "scientific visualization",
+            " scientific computing",
+            "computational chemistry",
+            " data science",
+            "cheminformatics",
+            "quantum chemistry",
+            "graphics",
+            "data science"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017,
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            6,
+            7,
+            6,
+            5,
+            7
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5660767872876544/",
+        "name": "Open Genome Informatics",
+        "tech": [
+            "neo4j",
+            "python",
+            "javascript",
+            "react",
+            "r-project",
+            "mysql"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "computational biology",
+            "biology",
+            " genomics",
+            " bioinformatics",
+            "data and databases",
+            "genomics",
+            "bioinformatics"
+        ],
+        "year": [
+            2021,
+            2020,
+            2017,
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            6,
+            8,
+            0,
+            0,
+            5,
+            6
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6381326080409600/",
+        "name": "Open Roberta",
+        "tech": [
+            "java",
+            "javascript",
+            "typescript",
+            "python",
+            "c++",
+            "go"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            " education",
+            "web",
+            "visual programming",
+            " robotics",
+            "robotics",
+            "education"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            3,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5551857973329920/",
+        "name": "Open Source Robotics Foundation",
+        "tech": [
+            "ros",
+            "gazebo",
+            "c++",
+            "python"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "robotics"
+        ],
+        "year": [
+            2020,
+            2019,
+            2018,
+            2016,
+            2015,
+            2014,
+            2013
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            3,
+            5,
+            6,
+            7,
+            0,
+            4,
+            7,
+            7,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4577601315667968/",
+        "name": "OpenAstronomy",
+        "tech": [
+            "python",
+            "julia",
+            "spark",
+            "numba",
+            "javascript"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "astronomy",
+            "solar physics",
+            "orbital mechanics",
+            "high energy astrophysics",
+            "cloud infrastructure"
+        ],
+        "year": [
+            2020,
+            2018,
+            2017,
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            7,
+            8,
+            8,
+            0,
+            10,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5722622045716480/",
+        "name": "OpenCV",
+        "tech": [
+            "c/c++",
+            "python 3",
+            "javascript",
+            "cuda",
+            "c++",
+            "opengl"
+        ],
+        "cat": "Graphics / Video / Audio / Virtual Reality",
+        "top": [
+            "computer vision",
+            "deep learning",
+            "machine learning",
+            "robotics",
+            "graphics"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2017,
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            11,
+            15,
+            0,
+            8,
+            14,
+            11
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6277255937916928/",
+        "name": "OpenEMR",
+        "tech": [
+            "php",
+            "mysql",
+            "javascript",
+            "docker",
+            "html"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "medical records",
+            "health",
+            "cloud",
+            "medicine",
+            "medical practice management solution"
+        ],
+        "year": [
+            2020
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6405402461208576/",
+        "name": "OpenHMD",
+        "tech": [
+            "c99",
+            "opengl",
+            "vulkan",
+            "opencv",
+            "libusb"
+        ],
+        "cat": "Graphics / Video / Audio / Virtual Reality",
+        "top": [
+            "virtual reality",
+            "xr",
+            "drivers",
+            "reverse engineering",
+            "computer vision"
+        ],
+        "year": [
+            2020
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5769029704220672/",
+        "name": "OpenMined",
+        "tech": [
+            "deep learning",
+            "federated learning",
+            "homomorphic encryption",
+            "secure multi-party computation",
+            "differential privacy",
+            "python",
+            "rust",
+            "pytorch",
+            "hyperledger aries",
+            "javascript"
+        ],
+        "cat": "Other",
+        "top": [
+            "privacy",
+            "artificial intelligence",
+            "encrypted computation",
+            "federated learning",
+            "structured transparency",
+            "differential privacy"
+        ],
+        "year": [
+            2021,
+            2020
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            4,
+            5
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5663972321132544/",
+        "name": "OpenMRS",
+        "tech": [
+            "java",
+            "javascript",
+            "spring",
+            "mysql",
+            "android"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "science and medicine",
+            "open source medical records",
+            " developing countries",
+            "open source",
+            "electronic medical records"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017,
+            2016,
+            2015,
+            2014,
+            2013,
+            2012,
+            2011,
+            2010,
+            2009
+        ],
+        "project": [
+            12,
+            13,
+            15,
+            17,
+            11,
+            12,
+            14,
+            9,
+            15,
+            10,
+            12,
+            9,
+            11
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6727913602285568/",
+        "name": "OpenRefine",
+        "tech": [
+            "java",
+            "javascript"
+        ],
+        "cat": "Data and Databases",
+        "top": [
+            "real-time",
+            "data visualization",
+            " data integration",
+            "web application"
+        ],
+        "year": [
+            2020
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5165116701540352/",
+        "name": "OpenStreetMap",
+        "tech": [
+            "javascript",
+            "java",
+            "python",
+            "sql",
+            "docker",
+            "ruby",
+            "postgresql"
+        ],
+        "cat": "Data and Databases",
+        "top": [
+            "maps",
+            "open data",
+            "crowdsourcing",
+            "gis"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017,
+            2016,
+            2015,
+            2012,
+            2011,
+            2010,
+            2009
+        ],
+        "project": [
+            6,
+            6,
+            3,
+            5,
+            0,
+            0,
+            7,
+            4,
+            5,
+            5,
+            5,
+            4,
+            4
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5137006207696896/",
+        "name": "openSUSE Project",
+        "tech": [
+            "linux",
+            "python",
+            "perl",
+            "rpm",
+            "javascript",
+            "kubernetes",
+            "artificial intelligence",
+            "rust"
+        ],
+        "cat": "Operating Systems",
+        "top": [
+            "tools",
+            "operating systems",
+            "software quality",
+            "build tools",
+            "containers",
+            "devops",
+            "developer tools"
+        ],
+        "year": [
+            2021,
+            2020,
+            2011,
+            2009
+        ],
+        "project": [
+            6,
+            0,
+            13,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            6
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5206079750799360/",
+        "name": "OpenWISP",
+        "tech": [
+            "python",
+            "django",
+            "openwrt",
+            "javascript",
+            "lua"
+        ],
+        "cat": "Web",
+        "top": [
+            "iot",
+            " networking",
+            "network visualization",
+            "wireless networks",
+            "network automation",
+            "network management system",
+            "wifi",
+            "mesh",
+            "hotspot"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            5,
+            2,
+            2,
+            3,
+            5
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5223170600075264/",
+        "name": "Oppia Foundation",
+        "tech": [
+            "angular",
+            "python",
+            "css",
+            "kotlin",
+            "webpack",
+            "typescript"
+        ],
+        "cat": "Web",
+        "top": [
+            "education",
+            " web",
+            " interactive",
+            " tools",
+            " community",
+            "web",
+            "interactive",
+            "nonprofit",
+            "community"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017,
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            3,
+            7,
+            4,
+            12,
+            18
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6255426160558080/",
+        "name": "Orcasound",
+        "tech": [
+            "elixir",
+            "react",
+            "javascript",
+            "python",
+            "raspberry pi"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "real-time",
+            "audio",
+            "citizen science",
+            "machine learning",
+            "web application",
+            "audio analysis",
+            "scientific visualization"
+        ],
+        "year": [
+            2021,
+            2020
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            4
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5355444958134272/",
+        "name": "OSGeo",
+        "tech": [
+            "c/c++",
+            "python",
+            "sql",
+            "open source databases",
+            "java"
+        ],
+        "cat": "Other",
+        "top": [
+            "gis",
+            "geolocation",
+            " mapping",
+            " open science",
+            "citizen science"
+        ],
+        "year": [
+            2020,
+            2019,
+            2018,
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            13,
+            10,
+            7,
+            10,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5704942551040000/",
+        "name": "OWASP Foundation",
+        "tech": [
+            "python",
+            "javascript",
+            ".net",
+            "node.js",
+            "c/c++",
+            "golang"
+        ],
+        "cat": "Security",
+        "top": [
+            "application security",
+            "web application security",
+            "information security",
+            "cyber security",
+            "cybersecurity",
+            "top 10",
+            "pentesting"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2016,
+            2014,
+            2012
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            4,
+            0,
+            16,
+            0,
+            5,
+            0,
+            8,
+            12,
+            12,
+            14
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5117265531371520/",
+        "name": "PEcAn Project",
+        "tech": [
+            "r",
+            "python",
+            "docker",
+            "postgresql",
+            "kubernetes",
+            "api"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "ecosystem models",
+            "scientific visualization",
+            "ecological forecasting",
+            "data science",
+            "climate science"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            1,
+            2,
+            3,
+            4
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5002697415065600/",
+        "name": "Percona",
+        "tech": [
+            "javascript",
+            "shell script",
+            "golang",
+            "prometheus",
+            "grafana"
+        ],
+        "cat": "Data and Databases",
+        "top": [
+            "data visualization",
+            "automation",
+            "load testing",
+            "alerts",
+            "testing"
+        ],
+        "year": [
+            2020,
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            1,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5233572744527872/",
+        "name": "Performance Co-Pilot",
+        "tech": [
+            "c",
+            "redis",
+            "grafana",
+            "rest",
+            "libuv"
+        ],
+        "cat": "Operating Systems",
+        "top": [
+            "performance",
+            "analysis",
+            "distributed",
+            "timeseries",
+            "lightweight"
+        ],
+        "year": [
+            2020,
+            2019,
+            2018,
+            2017,
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            5,
+            5,
+            2,
+            3,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5952433766793216/",
+        "name": "Pitivi",
+        "tech": [
+            "gtk",
+            "gstreamer",
+            "c",
+            "python 3",
+            "python"
+        ],
+        "cat": "Graphics / Video / Audio / Virtual Reality",
+        "top": [
+            "filmmaking",
+            " video editing",
+            " video processing",
+            "video editing",
+            "video processing"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            3,
+            2
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6260986197049344/",
+        "name": "Point Cloud Library",
+        "tech": [
+            "cpp",
+            "cmake",
+            "devops",
+            "computer vision",
+            "c++14",
+            "python",
+            "cuda"
+        ],
+        "cat": "Graphics / Video / Audio / Virtual Reality",
+        "top": [
+            "3d computer vision",
+            " robotics",
+            "perception",
+            "robotics",
+            "computer vision",
+            "2d/3d graphics",
+            "data structures",
+            "gpu computing"
+        ],
+        "year": [
+            2021,
+            2020
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            3
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6316019928268800/",
+        "name": "PostgreSQL",
+        "tech": [
+            "postgresql",
+            "postgres",
+            "sql",
+            "c",
+            "perl",
+            "python",
+            "julia"
+        ],
+        "cat": "Data and Databases",
+        "top": [
+            "data",
+            "database",
+            "rdbms",
+            "sql",
+            "data management",
+            "relational database",
+            "web",
+            "postgresql"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017,
+            2010
+        ],
+        "project": [
+            0,
+            5,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            4,
+            3,
+            4,
+            3,
+            6
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5124239249637376/",
+        "name": "Postman",
+        "tech": [
+            "node.js",
+            "javascript",
+            "graphql",
+            "openapi",
+            "rest api"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "api management",
+            " developer tools",
+            "api",
+            "programmer productivity",
+            "programming languages and development tools",
+            "software development",
+            "productivity",
+            "apis"
+        ],
+        "year": [
+            2021,
+            2020
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            9
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/4923136667025408/",
+        "name": "Processing Foundation",
+        "tech": [
+            "python",
+            "android",
+            "opengl",
+            "java",
+            "javascript",
+            "javascr"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "creative coding",
+            "graphics",
+            "web",
+            " education",
+            "design",
+            "education"
+        ],
+        "year": [
+            2021,
+            2020
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            11,
+            11
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5146061710032896/",
+        "name": "Purr Data",
+        "tech": [
+            "html5",
+            "javascript",
+            "opengl",
+            "svg",
+            "c/c++",
+            "c",
+            "c++",
+            "html",
+            "css"
+        ],
+        "cat": "Graphics / Video / Audio / Virtual Reality",
+        "top": [
+            "real-time",
+            "audio",
+            "2d/3d graphics",
+            "visual programming",
+            "music",
+            "graphics / video / audio / virtual reality",
+            "web development"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            1,
+            3,
+            3
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5068943793848320/",
+        "name": "Python Software Foundation",
+        "tech": [
+            "python"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "security",
+            "machine learning",
+            "ui design",
+            "science",
+            "programming languages",
+            "science and medicine"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017,
+            2016,
+            2015,
+            2014,
+            2013,
+            2012,
+            2011,
+            2010,
+            2009
+        ],
+        "project": [
+            25,
+            31,
+            30,
+            26,
+            33,
+            40,
+            62,
+            49,
+            29,
+            14,
+            30,
+            24,
+            34
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/4837236381581312/",
+        "name": "QEMU",
+        "tech": [
+            "linux",
+            "kvm",
+            "c",
+            "virtualization",
+            "rust",
+            "python"
+        ],
+        "cat": "Cloud",
+        "top": [
+            "emulator",
+            "hypervisor",
+            "lowlevel",
+            "code generation",
+            "compiler"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017,
+            2016,
+            2015,
+            2014
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            6,
+            7,
+            6,
+            4,
+            4,
+            3,
+            3,
+            6
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5682513023860736/",
+        "name": "Qubes OS",
+        "tech": [
+            "c",
+            "python",
+            "xen",
+            "shell",
+            "linux",
+            "ruby"
+        ],
+        "cat": "Operating Systems",
+        "top": [
+            "virtualization",
+            "operating systems",
+            "security",
+            "privacy"
+        ],
+        "year": [
+            2021,
+            2020,
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            0,
+            1,
+            1
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4761521042751488/",
+        "name": "R Project for Statistical Computing",
+        "tech": [
+            "r-project",
+            "c",
+            "c++",
+            "fortran",
+            "javascript"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "data science",
+            "data visualization",
+            "statistics",
+            "graphics",
+            "machine learning"
+        ],
+        "year": [
+            2020,
+            2015,
+            2014,
+            2010
+        ],
+        "project": [
+            0,
+            4,
+            0,
+            0,
+            0,
+            17,
+            23,
+            0,
+            0,
+            0,
+            0,
+            20,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6102444192301056/",
+        "name": "Radare",
+        "tech": [
+            "c",
+            "c++",
+            "python",
+            "go",
+            "qt"
+        ],
+        "cat": "Security",
+        "top": [
+            "reverse engineering",
+            "disassembly",
+            "debugging",
+            "program analysis"
+        ],
+        "year": [
+            2020
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            4,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5679527786708992/",
+        "name": "ReactOS",
+        "tech": [
+            "c",
+            "c++",
+            "win32",
+            "nt"
+        ],
+        "cat": "Operating Systems",
+        "top": [
+            "operating systems",
+            "drivers",
+            "kernel",
+            "windows",
+            "applications"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017,
+            2016,
+            2011
+        ],
+        "project": [
+            0,
+            0,
+            4,
+            0,
+            0,
+            0,
+            0,
+            4,
+            4,
+            1,
+            2,
+            3,
+            1
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5946697670197248/",
+        "name": "Red Hen Lab",
+        "tech": [
+            "nlp",
+            "asr",
+            "opencv",
+            "machine learning",
+            "data science",
+            "python",
+            "machinelearning",
+            "computer vision",
+            "big data science"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "multimedia",
+            "data science",
+            "communication",
+            "big data",
+            "cognitive science",
+            "multimodal communication",
+            "language",
+            "gesture",
+            "metadata",
+            "media"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017,
+            2016,
+            2015
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            5,
+            9,
+            10,
+            15,
+            8,
+            12
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6285571999137792/",
+        "name": "RoboComp",
+        "tech": [
+            "python",
+            "c++11",
+            "component-based development",
+            "qt",
+            "opencv",
+            "c++17",
+            "qt5",
+            "pytorch"
+        ],
+        "cat": "Other",
+        "top": [
+            "robotics",
+            " computer vision",
+            " multi-agent system",
+            " component-based development",
+            "computer vision",
+            "multi-agent system",
+            "component-based development"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017,
+            2015,
+            2013
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            4,
+            0,
+            9,
+            8,
+            10,
+            10,
+            10
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6240940410273792/",
+        "name": "Rocket.Chat",
+        "tech": [
+            "javascript",
+            "react",
+            "reactnative",
+            "chatbots",
+            "ruby",
+            "nodejs",
+            "react native",
+            "kubernetes",
+            "docker"
+        ],
+        "cat": "Social / Communications",
+        "top": [
+            "social-network",
+            "communication",
+            "collaboration",
+            "team chat",
+            "instant messaging",
+            "community",
+            "team"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            4,
+            7,
+            15,
+            7,
+            12
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5979439984279552/",
+        "name": "RTEMS Project",
+        "tech": [
+            "c/c++",
+            "python",
+            "assembly",
+            "posix",
+            "bsd unix"
+        ],
+        "cat": "Operating Systems",
+        "top": [
+            "real time",
+            " kernel",
+            " embedded systems",
+            " multicore",
+            " iot cps",
+            "embedded systems",
+            "multicore",
+            "iot cps",
+            "kernel",
+            "real-time"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017,
+            2016,
+            2015,
+            2014,
+            2013,
+            2012,
+            2011,
+            2010,
+            2009
+        ],
+        "project": [
+            6,
+            8,
+            8,
+            10,
+            8,
+            5,
+            9,
+            5,
+            4,
+            4,
+            4,
+            5,
+            4
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5432182465626112/",
+        "name": "Ruby",
+        "tech": [
+            "ruby",
+            "c",
+            "java",
+            "ruby on rails"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "programming language",
+            " developer tools",
+            " web servers",
+            "cloud",
+            "web development",
+            "type system",
+            "performance optimization"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2016,
+            2015
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            6,
+            12,
+            0,
+            5,
+            5,
+            4,
+            5
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5180088957534208/",
+        "name": "SageMath",
+        "tech": [
+            "python",
+            "cython"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "mathematics",
+            " education",
+            " research",
+            " math",
+            "education",
+            "research"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            4,
+            5,
+            7
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5673937584783360/",
+        "name": "Samba",
+        "tech": [
+            "smb",
+            "cifs",
+            "c",
+            "python"
+        ],
+        "cat": "Data and Databases",
+        "top": [
+            " networking",
+            "networking",
+            "enterprise"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2017,
+            2014,
+            2013,
+            2012,
+            2011,
+            2010,
+            2009
+        ],
+        "project": [
+            3,
+            3,
+            4,
+            3,
+            3,
+            3,
+            0,
+            0,
+            1,
+            0,
+            1,
+            1,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5416561266917376/",
+        "name": "SCoRe Lab",
+        "tech": [
+            "python",
+            "mobile",
+            "cloud",
+            "web development",
+            "machine learning",
+            "nodejs",
+            "android",
+            "golang"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "information security",
+            "mobile",
+            "cloud",
+            "web development",
+            "machine learning"
+        ],
+        "year": [
+            2021,
+            2020
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            25,
+            23
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5723178982178816/",
+        "name": "ScummVM",
+        "tech": [
+            "c++",
+            "sdl",
+            "opengl",
+            "assembly",
+            "lua"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "games",
+            " game engines",
+            " software preservation",
+            " software archeology",
+            "game engines",
+            "software preservation",
+            "software archeology"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017,
+            2016,
+            2014,
+            2013,
+            2012,
+            2011,
+            2010,
+            2009
+        ],
+        "project": [
+            4,
+            4,
+            1,
+            3,
+            4,
+            5,
+            0,
+            3,
+            2,
+            3,
+            3,
+            4,
+            5
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4722091934351360/",
+        "name": "Shogun",
+        "tech": [
+            "python",
+            "c++",
+            "data science",
+            "machine learning",
+            "matlab"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "machine learning",
+            " scientific computing",
+            " software engineering",
+            " user experience",
+            " data science"
+        ],
+        "year": [
+            2020
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/4886205283434496/",
+        "name": "SPDX",
+        "tech": [
+            "python",
+            "java",
+            "golang",
+            "node.js",
+            "xml",
+            "rdf",
+            "json"
+        ],
+        "cat": "Other",
+        "top": [
+            "open source",
+            "compliance",
+            "licensing",
+            "security",
+            "standards"
+        ],
+        "year": [
+            2021,
+            2020,
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            4,
+            0,
+            4,
+            4
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6742658493448192/",
+        "name": "Ste||ar group",
+        "tech": [
+            "cpp",
+            "hpx",
+            "python",
+            "hpc",
+            "cuda"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "high performance computing",
+            "asynchronous manytask systems",
+            "machine learning",
+            "deep learning"
+        ],
+        "year": [
+            2020
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            5,
+            0
+        ]
+    },
+    {
+        "name": "openastronomy",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6276607395758080/",
+        "tech": [
+            "python",
+            "julia",
+            "numba",
+            "spark",
+            "javascript"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "astronomy",
+            "solar physics",
+            "high energy astrophysics",
+            "astrophysics"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            8
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6067595530207232/",
+        "name": "strace",
+        "tech": [
+            "linux",
+            "c",
+            "shell",
+            "make",
+            "awk",
+            "git",
+            "shell script"
+        ],
+        "cat": "Operating Systems",
+        "top": [
+            "diagnostic",
+            "debugging",
+            "tracing"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017,
+            2016,
+            2015,
+            2014
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            1,
+            4,
+            4,
+            2,
+            2,
+            1,
+            1
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5702344097923072/",
+        "name": "Submitty",
+        "tech": [
+            "php",
+            "python",
+            "postgresql",
+            "c++",
+            "javascript"
+        ],
+        "cat": "Other",
+        "top": [
+            "education",
+            "web",
+            "communication",
+            "visualization",
+            "privacy/security"
+        ],
+        "year": [
+            2020,
+            2019,
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            4,
+            3,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6572491585093632/",
+        "name": "Sugar Labs",
+        "tech": [
+            "python",
+            "javascript",
+            "gtk",
+            "pygame",
+            "c",
+            "python gtk",
+            "react",
+            "vue.js",
+            "typescript"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "education",
+            "software",
+            "open source",
+            "learning",
+            "collaboration"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017,
+            2016,
+            2015,
+            2014,
+            2013,
+            2010
+        ],
+        "project": [
+            0,
+            3,
+            0,
+            0,
+            7,
+            9,
+            5,
+            5,
+            9,
+            11,
+            8,
+            9,
+            8
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/4908645044715520/",
+        "name": "Swift",
+        "tech": [
+            "swift",
+            "c++",
+            "llvm"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "developer tools",
+            "programming languages",
+            "programming languages and development tools",
+            "package management",
+            "programming libraries",
+            "debugging",
+            "compilers"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            4,
+            5
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/4577761535983616/",
+        "name": "SymbiFlow",
+        "tech": [
+            "c/c++",
+            "fpga",
+            "python",
+            "verilog"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "fpga",
+            "programming languages and development tools",
+            "programming languages",
+            "development tools",
+            "open hardware"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            3,
+            1
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5401117973807104/",
+        "name": "SymPy",
+        "tech": [
+            "python"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "mathematics",
+            "symbolic mathematics",
+            "physics"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017,
+            2016,
+            2014,
+            2013,
+            2012,
+            2011
+        ],
+        "project": [
+            0,
+            0,
+            9,
+            6,
+            7,
+            10,
+            0,
+            7,
+            8,
+            7,
+            10,
+            6,
+            6
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6046097876713472/",
+        "name": "Synfig",
+        "tech": [
+            "c++",
+            "gtk",
+            "gtkmm",
+            "python",
+            "c++11"
+        ],
+        "cat": "Graphics / Video / Audio / Virtual Reality",
+        "top": [
+            "vector graphics",
+            "animation",
+            "2d/3d graphics",
+            "2d animation"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            2,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6224442098712576/",
+        "name": "syslog-ng",
+        "tech": [
+            "elasticsearch",
+            "kafka",
+            "sql",
+            "python",
+            "c"
+        ],
+        "cat": "Other",
+        "top": [
+            " cloud",
+            "logging",
+            "high performance data processing",
+            "reliable log transfer",
+            "data processing pipeline",
+            "cloud"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            1,
+            2
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6024226160508928/",
+        "name": "TARDIS-SN",
+        "tech": [
+            "python"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "astronomy",
+            "supernova",
+            "science"
+        ],
+        "year": [
+            2020,
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            0,
+            0,
+            0,
+            3,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6649841832165376/",
+        "name": "TensorFlow",
+        "tech": [
+            "machine learning",
+            "deep learning",
+            "python",
+            "data analysis",
+            "c/c++",
+            "python deep learning frameworks",
+            "javascript"
+        ],
+        "cat": "Other",
+        "top": [
+            "deep learning",
+            "machine learning",
+            "python",
+            "data",
+            "data science",
+            "computer vision",
+            "natural language processing",
+            "cloud computing"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            19,
+            17,
+            17
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5149287498907648/",
+        "name": "The Apache Software Foundation",
+        "tech": [
+            "java",
+            "c++",
+            "c",
+            "rust"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            " big data",
+            "cloud",
+            "libraries",
+            "big data"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2009
+        ],
+        "project": [
+            32,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            17,
+            17,
+            28
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5461276207087616/",
+        "name": "The GNU Project",
+        "tech": [
+            "c/c++",
+            "javascript",
+            "android",
+            "python",
+            "scheme"
+        ],
+        "cat": "Operating Systems",
+        "top": [
+            "http",
+            "operating systems",
+            "package managers",
+            "astronomy",
+            "reverse engineering"
+        ],
+        "year": [
+            2020,
+            2019,
+            2017,
+            2010
+        ],
+        "project": [
+            0,
+            14,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            13,
+            0,
+            5,
+            7,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5942967122001920/",
+        "name": "The Honeynet Project",
+        "tech": [
+            "python",
+            "golang",
+            "honeypot",
+            "machine learning",
+            "networking",
+            "django",
+            "c",
+            "docker",
+            "c++"
+        ],
+        "cat": "Security",
+        "top": [
+            "honeynets",
+            "honeypots",
+            "deception",
+            "research",
+            "malware",
+            "honeypot",
+            "fuzzing",
+            "hypervisor introspection",
+            "network analysis",
+            "malware analysis"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017,
+            2016,
+            2015,
+            2013,
+            2012,
+            2011,
+            2010,
+            2009
+        ],
+        "project": [
+            9,
+            16,
+            12,
+            15,
+            13,
+            0,
+            7,
+            11,
+            12,
+            17,
+            9,
+            11,
+            11
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4643042893496320/",
+        "name": "The Java Pathfinder Team",
+        "tech": [
+            "javajava",
+            "jvm",
+            "android",
+            "distributed systems"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "program analysis",
+            " test input generation",
+            " model checking",
+            " symbolic execution",
+            " verification of concurrent systems"
+        ],
+        "year": [
+            2020,
+            2019,
+            2018,
+            2017,
+            2013,
+            2012,
+            2011,
+            2010
+        ],
+        "project": [
+            0,
+            8,
+            11,
+            11,
+            15,
+            0,
+            0,
+            0,
+            7,
+            4,
+            6,
+            6,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5086646441082880/",
+        "name": "The Julia Language",
+        "tech": [
+            "julia",
+            "julialang"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "technical computing",
+            "data science",
+            "scientific computing",
+            "machine learning",
+            "numerical computing"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2017,
+            2016,
+            2014
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            0,
+            10,
+            16,
+            0,
+            13,
+            15,
+            20
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6271961616875520/",
+        "name": "The Libreswan Project",
+        "tech": [
+            "c",
+            "python",
+            "kvm",
+            "namespaces"
+        ],
+        "cat": "Security",
+        "top": [
+            "vpn",
+            "ipsec",
+            "ike",
+            "encryption",
+            "ikev2",
+            "security"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            3,
+            1,
+            3,
+            1
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5715751809318912/",
+        "name": "The Linux Foundation",
+        "tech": [
+            "c",
+            "c++",
+            "cups",
+            "ipp",
+            "linux"
+        ],
+        "cat": "Operating Systems",
+        "top": [
+            "automotive",
+            "printing",
+            "kernel",
+            "lsb",
+            "spdx",
+            "iio"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017,
+            2016,
+            2014,
+            2013,
+            2012,
+            2011,
+            2010,
+            2009
+        ],
+        "project": [
+            7,
+            11,
+            12,
+            14,
+            14,
+            15,
+            0,
+            11,
+            11,
+            12,
+            7,
+            13,
+            18
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5738954464165888/",
+        "name": "The LLVM Compiler Infrastructure",
+        "tech": [
+            "llvm",
+            "clang",
+            "mlir",
+            "c/c++"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "compilers",
+            "debuggers",
+            "code analysis",
+            "programming languages and development tools"
+        ],
+        "year": [
+            2021,
+            2020,
+            2016,
+            2011
+        ],
+        "project": [
+            0,
+            0,
+            7,
+            0,
+            0,
+            0,
+            0,
+            7,
+            0,
+            0,
+            0,
+            15,
+            16
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6055344943398912/",
+        "name": "The Mifos Initiative",
+        "tech": [
+            "android",
+            "java",
+            "angular",
+            "mysql",
+            "spring"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "fintech",
+            "mobile banking",
+            "cloud",
+            "big data",
+            "web"
+        ],
+        "year": [
+            2020,
+            2019,
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            12,
+            14,
+            17,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5674199175135232/",
+        "name": "The NetBSD Foundation",
+        "tech": [
+            "c",
+            "bsd make",
+            "bsd unix",
+            "make",
+            "shell script"
+        ],
+        "cat": "Operating Systems",
+        "top": [
+            "kernel",
+            "userland",
+            "unix",
+            "packaging",
+            "bsd"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017,
+            2016,
+            2013,
+            2012,
+            2011,
+            2010
+        ],
+        "project": [
+            0,
+            6,
+            8,
+            6,
+            4,
+            0,
+            0,
+            4,
+            3,
+            4,
+            7,
+            6,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6270070723969024/",
+        "name": "The ns-3 Network Simulator Project",
+        "tech": [
+            "c/c++",
+            "python",
+            "c++",
+            "python 3"
+        ],
+        "cat": "Other",
+        "top": [
+            "research",
+            " networking",
+            "simulation",
+            "network analysis",
+            "emulation"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017,
+            2015,
+            2014,
+            2013,
+            2012,
+            2010,
+            2009
+        ],
+        "project": [
+            3,
+            4,
+            0,
+            3,
+            2,
+            4,
+            4,
+            0,
+            5,
+            5,
+            4,
+            4,
+            3
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/4867306789797888/",
+        "name": "The Terasology Foundation",
+        "tech": [
+            "java",
+            "lwgjl",
+            "opengl",
+            "blender",
+            "gradle",
+            "lwjgl",
+            "kotlin"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "games",
+            "ai",
+            "graphics",
+            "voxel",
+            "sandbox",
+            "game engines",
+            "graphics / video / audio / virtual reality"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            9,
+            8,
+            4
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/6331124088832000/",
+        "name": "The Wine Project",
+        "tech": [
+            "c",
+            "opengl",
+            "directx",
+            "win32",
+            "vulkan"
+        ],
+        "cat": "Other",
+        "top": [
+            "compatibility",
+            " 3d",
+            " directx",
+            " opengl",
+            "vulkan"
+        ],
+        "year": [
+            2020,
+            2019,
+            2018,
+            2017,
+            2016,
+            2015,
+            2014,
+            2010,
+            2009
+        ],
+        "project": [
+            5,
+            4,
+            0,
+            0,
+            0,
+            3,
+            4,
+            2,
+            0,
+            2,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6526086241845248/",
+        "name": "VideoLAN",
+        "tech": [
+            "c++",
+            "asm",
+            "c",
+            "go",
+            "c#",
+            "machine learning",
+            "video codecs",
+            "audio"
+        ],
+        "cat": "Graphics / Video / Audio / Virtual Reality",
+        "top": [
+            "multimedia",
+            " video processing",
+            "vr",
+            "audio",
+            "video",
+            "video decode",
+            "network programming"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017,
+            2011,
+            2010,
+            2009
+        ],
+        "project": [
+            12,
+            14,
+            12,
+            0,
+            0,
+            0,
+            0,
+            0,
+            9,
+            10,
+            9,
+            8,
+            9
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5144337383424000/",
+        "name": "webpack",
+        "tech": [
+            "javascript",
+            "webpack"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "web development"
+        ],
+        "year": [
+            2020,
+            2019,
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            2,
+            1,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5270263742070784/",
+        "name": "Wikimedia Foundation",
+        "tech": [
+            "html",
+            "css",
+            "python",
+            "javascript",
+            "php"
+        ],
+        "cat": "Web",
+        "top": [
+            " mediawiki",
+            " semantic web",
+            " i18n",
+            "wikipedia",
+            "wikimedia",
+            "mediawiki",
+            "semantic web",
+            "i18n"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017,
+            2016,
+            2015,
+            2012,
+            2011,
+            2010,
+            2009
+        ],
+        "project": [
+            4,
+            6,
+            7,
+            8,
+            0,
+            0,
+            8,
+            6,
+            7,
+            12,
+            11,
+            14,
+            10
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5630325851422720/",
+        "name": "Wireshark",
+        "tech": [
+            "qt",
+            "c/c++",
+            "lua",
+            "pcap",
+            "cmake"
+        ],
+        "cat": "Security",
+        "top": [
+            "network monitoring",
+            "data visualization",
+            "network security"
+        ],
+        "year": [
+            2020,
+            2013
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            3,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5883488672153600/",
+        "name": "X.Org Foundation",
+        "tech": [
+            "x11",
+            "opencl",
+            "opengl",
+            "wayland",
+            "vulkan"
+        ],
+        "cat": "Graphics / Video / Audio / Virtual Reality",
+        "top": [
+            "graphics stack",
+            "2d/3d graphics",
+            "windowing systems",
+            "testing/ci",
+            "gpu"
+        ],
+        "year": [
+            2020,
+            2019,
+            2017,
+            2016,
+            2015,
+            2014,
+            2013,
+            2011
+        ],
+        "project": [
+            0,
+            0,
+            4,
+            0,
+            3,
+            4,
+            5,
+            2,
+            4,
+            0,
+            2,
+            1,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/4524333319323648/",
+        "name": "Xapian Search Engine Library",
+        "tech": [
+            "c++",
+            "unicode",
+            "swig",
+            "linux",
+            "golang"
+        ],
+        "cat": "Data and Databases",
+        "top": [
+            "search",
+            "information retrieval",
+            "machine learning",
+            "linguistics",
+            "indexing"
+        ],
+        "year": [
+            2020,
+            2019,
+            2018,
+            2017,
+            2016,
+            2014,
+            2012,
+            2011
+        ],
+        "project": [
+            0,
+            0,
+            4,
+            4,
+            0,
+            3,
+            0,
+            5,
+            3,
+            2,
+            3,
+            2,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2020/organizations/5153224375402496/",
+        "name": "XMPP Standards Foundation",
+        "tech": [
+            "java",
+            "xmpp",
+            "vala",
+            "webrtc",
+            "lua"
+        ],
+        "cat": "Social / Communications",
+        "top": [
+            "instant messaging",
+            "realtime communication",
+            "voip"
+        ],
+        "year": [
+            2020,
+            2017,
+            2015,
+            2012,
+            2011,
+            2010
+        ],
+        "project": [
+            0,
+            4,
+            4,
+            7,
+            0,
+            0,
+            6,
+            0,
+            2,
+            0,
+            0,
+            2,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5665151457427456/",
+        "name": "XWiki",
+        "tech": [
+            "java",
+            "javascript",
+            "html5",
+            "css",
+            "velocity",
+            "css3"
+        ],
+        "cat": "Web",
+        "top": [
+            "web development",
+            "wiki",
+            "platform",
+            "web applications",
+            "structured data"
+        ],
+        "year": [
+            2021,
+            2020,
+            2019,
+            2018,
+            2017,
+            2016,
+            2012,
+            2011,
+            2009
+        ],
+        "project": [
+            4,
+            0,
+            3,
+            3,
+            0,
+            0,
+            0,
+            0,
+            2,
+            3,
+            3,
+            1,
+            1
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5441147069005824/",
+        "name": "Zulip",
+        "tech": [
+            "python",
+            "react native",
+            "django",
+            "typescript",
+            "electron"
+        ],
+        "cat": "Social / Communications",
+        "top": [
+            "bots",
+            "mobile",
+            "chat",
+            "great developer tooling",
+            "visual design",
+            "teaching quality codebase"
+        ],
+        "year": [
+            2021,
+            2020,
+            2018,
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            10,
+            10,
+            0,
+            18,
+            18
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6331236958601216/",
+        "name": "52\u00b0North Initiative for Geospatial Open Source Software GmbH",
+        "tech": [
+            "javascript",
+            "android",
+            "web",
+            "java"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "ogc",
+            "web processing",
+            "sensorweb",
+            "floating car data",
+            "earth observation"
+        ],
+        "year": [
+            2019,
+            2017,
+            2016,
+            2015,
+            2014,
+            2013,
+            2012
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            4,
+            4,
+            4,
+            6,
+            3,
+            1,
+            0,
+            2,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5844178540429312/",
+        "name": "aimacode",
+        "tech": [
+            "python",
+            "python 3",
+            "java",
+            "javascript",
+            "machine learning"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "machine learning",
+            "artificial intelligence",
+            " education",
+            "open education"
+        ],
+        "year": [
+            2019,
+            2018,
+            2017,
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            4,
+            5,
+            4,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/4551437139312640/",
+        "name": "AOSSIE - Australian Open Source Software Innovation and Education",
+        "tech": [
+            "scala",
+            "javascript",
+            "isabelle proof assistant",
+            "android",
+            "ios"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "electronic voting",
+            "natural language processing",
+            "environment",
+            "machine learning",
+            "philosophy"
+        ],
+        "year": [
+            2019,
+            2018,
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            13,
+            13,
+            18,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6340359469137920/",
+        "name": "API Client Tools at Google",
+        "tech": [
+            "openapi",
+            "grpc",
+            "protocol buffers",
+            "rpc",
+            "rest"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "apis",
+            "automation",
+            "code generation",
+            "api description"
+        ],
+        "year": [
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5485316792647680/",
+        "name": "appleseedhq",
+        "tech": [
+            "c++11",
+            "python",
+            "opengl"
+        ],
+        "cat": "Graphics / Video / Audio / Virtual Reality",
+        "top": [
+            "computer graphics",
+            "image synthesis",
+            "rendering",
+            "animation",
+            "simulation"
+        ],
+        "year": [
+            2019,
+            2018,
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            3,
+            2,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6052415684476928/",
+        "name": "Ardupilot.org",
+        "tech": [
+            "drones",
+            "python",
+            "linux",
+            "robotics",
+            "c/c++"
+        ],
+        "cat": "Other",
+        "top": [
+            "vison",
+            "robotics",
+            "embedded systems",
+            "real-time os",
+            "drones"
+        ],
+        "year": [
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            5,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5906507105828864/",
+        "name": "Bazel",
+        "tech": [
+            "windows",
+            "c/c++",
+            "java",
+            "bazel"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "build tools",
+            "developer tools"
+        ],
+        "year": [
+            2019,
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5781930639884288/",
+        "name": "Berkman Klein Center for Internet and Society",
+        "tech": [
+            "ruby on rails",
+            "meteor.js",
+            "elasticsearch",
+            "python",
+            "java"
+        ],
+        "cat": "Other",
+        "top": [
+            "web",
+            "research",
+            "education",
+            "internet freedom",
+            "internet censorship"
+        ],
+        "year": [
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/4661625682919424/",
+        "name": "Biomedical Informatics, Emory University",
+        "tech": [
+            "python",
+            "java",
+            "deep learning",
+            "medical imaging",
+            "tensorflow"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "data integration",
+            "distributed systems",
+            "cloud",
+            "precision medicine",
+            "science and medicine"
+        ],
+        "year": [
+            2019,
+            2016,
+            2015,
+            2014
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            4,
+            4,
+            5,
+            0,
+            0,
+            4,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5526850200141824/",
+        "name": "Buildroot",
+        "tech": [
+            "gnu make",
+            "kconfig",
+            "python",
+            "shell"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "embedded systems",
+            "linux",
+            "build tools",
+            "compilation"
+        ],
+        "year": [
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5152322794029056/",
+        "name": "Canadian Center for Computational Genomics",
+        "tech": [
+            "python",
+            "r-project",
+            "javascript",
+            "react",
+            "nodejs"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "bioinformatics",
+            " science",
+            " visualization",
+            " statistics",
+            " web"
+        ],
+        "year": [
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            4,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6278222700871680/",
+        "name": "cBioPortal for Cancer Genomics",
+        "tech": [
+            "java",
+            "javascript",
+            "reactjs",
+            "database",
+            "web apps"
+        ],
+        "cat": "Data and Databases",
+        "top": [
+            "genomics",
+            "bioinformatics",
+            "big data",
+            "data visualization",
+            "cancer research"
+        ],
+        "year": [
+            2019,
+            2017,
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            5,
+            6,
+            0,
+            6,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6344880593305600/",
+        "name": "CBMI@UTHSC",
+        "tech": [
+            "reactjs",
+            "python",
+            "flask",
+            "javascript",
+            "tensorflow"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "machine learning",
+            "deep learning",
+            "sepsis prediction",
+            "sepsis detection",
+            " web applications"
+        ],
+        "year": [
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5907529257713664/",
+        "name": "Center for Research in Open Source Software at UC Santa Cruz",
+        "tech": [
+            "python",
+            "javascript",
+            "c/c++",
+            "verilog"
+        ],
+        "cat": "Other",
+        "top": [
+            "cloud databases",
+            "reproducibility",
+            "ceph",
+            "architecture",
+            "generative text"
+        ],
+        "year": [
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            4,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/4870847817318400/",
+        "name": "CGAL project",
+        "tech": [
+            "c++",
+            "git",
+            "swig",
+            "python"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "computational geometry",
+            "geometry processing",
+            "mesh processing",
+            "arrangement",
+            "point set processing"
+        ],
+        "year": [
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            9,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5344579304292352/",
+        "name": "CLiPS, University of Antwerp",
+        "tech": [
+            "python",
+            "javascript",
+            "mongodb"
+        ],
+        "cat": "Data and Databases",
+        "top": [
+            "natural language processing",
+            "machine learning",
+            "artificial intelligence",
+            "text analytics",
+            "text generation"
+        ],
+        "year": [
+            2019,
+            2018,
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            4,
+            4,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/4904398832009216/",
+        "name": "coala",
+        "tech": [
+            "python 3",
+            "java",
+            "angularjs",
+            "haskell",
+            "docker",
+            "django",
+            "antlr"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "code analysis",
+            " chatops",
+            " devops",
+            "static code analysis",
+            "chat",
+            "devops"
+        ],
+        "year": [
+            2021,
+            2019,
+            2018,
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            9,
+            14,
+            10,
+            0,
+            4
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6093511005306880/",
+        "name": "Computational Biology @ University of Nebraska-Lincoln",
+        "tech": [
+            "javascript",
+            "react",
+            "postgresql",
+            "webgl"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "web application",
+            "bioinformatics",
+            "computational biology",
+            "data science",
+            "network biology"
+        ],
+        "year": [
+            2019,
+            2018,
+            2017,
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            5,
+            4,
+            4,
+            5,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6267159469096960/",
+        "name": "CRIU (Checkpoint/Restore in User-space)",
+        "tech": [
+            "docker",
+            "linux",
+            "containers",
+            "kernel"
+        ],
+        "cat": "Operating Systems",
+        "top": [
+            "cloud",
+            "save/restore",
+            "load-balancing",
+            "zero-downtime",
+            "migration"
+        ],
+        "year": [
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6223494952517632/",
+        "name": "D Programming Language",
+        "tech": [
+            "dlang",
+            "linux",
+            "windows",
+            "osx",
+            "bsd"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "programming languages",
+            "object-oriented programming",
+            "functional programming",
+            "web programming",
+            "system programming"
+        ],
+        "year": [
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            5,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5926253033422848/",
+        "name": "Developers Italia",
+        "tech": [
+            "python",
+            "go",
+            "scala",
+            "node.js",
+            "html/css/js"
+        ],
+        "cat": "Other",
+        "top": [
+            "open government",
+            "public code",
+            " open source",
+            " web applications",
+            "open data"
+        ],
+        "year": [
+            2019,
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            3,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6180395375132672/",
+        "name": "Digital Impact Alliance",
+        "tech": [
+            "android",
+            "java",
+            "php",
+            "python",
+            "javascript"
+        ],
+        "cat": "Other",
+        "top": [
+            "end user application",
+            "humanitarian",
+            "international",
+            "social good",
+            "charity"
+        ],
+        "year": [
+            2019,
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            3,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6268499498893312/",
+        "name": "Earth Science Information Partners",
+        "tech": [
+            "python",
+            "kubernetes",
+            "jupyter",
+            "deep learning",
+            "gdal"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "earth observation",
+            "cloud databases",
+            " data visualisation",
+            "semantic web",
+            "data-science"
+        ],
+        "year": [
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5379070022385664/",
+        "name": "FOSDEM",
+        "tech": [
+            "javascript",
+            "grafana",
+            "voctomix",
+            "influxdb",
+            "ruby on rails"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "conference",
+            "web development",
+            "rails application",
+            "video processing"
+        ],
+        "year": [
+            2019,
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            2,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5483378286002176/",
+        "name": "FOSSASIA",
+        "tech": [
+            "javascript",
+            "python",
+            "java",
+            "reactjs",
+            "c"
+        ],
+        "cat": "Other",
+        "top": [
+            "artificial intelligence",
+            "event management",
+            "open science",
+            "voice assistants",
+            "search"
+        ],
+        "year": [
+            2019,
+            2018,
+            2017,
+            2016,
+            2015,
+            2014,
+            2012,
+            2011
+        ],
+        "project": [
+            0,
+            0,
+            3,
+            6,
+            0,
+            9,
+            17,
+            18,
+            51,
+            32,
+            14,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/4832912116023296/",
+        "name": "FOSSology Project",
+        "tech": [
+            "postgresql",
+            "php",
+            "c/c++",
+            "jquery",
+            "bash"
+        ],
+        "cat": "Other",
+        "top": [
+            "compliance",
+            "license-scan",
+            "oss licensing",
+            "spdx",
+            "oss compliance"
+        ],
+        "year": [
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5090343328940032/",
+        "name": "FrameNet Brasil at the Federal University of Juiz de Fora",
+        "tech": [
+            "php",
+            "mysql",
+            "javascript",
+            "python"
+        ],
+        "cat": "Data and Databases",
+        "top": [
+            "natural language processing",
+            "multimodality",
+            "natural language understanding",
+            "image processing",
+            "machine translation"
+        ],
+        "year": [
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6504969929228288/",
+        "name": "FreeBSD",
+        "tech": [
+            "c/c++",
+            "llvm",
+            "shell script",
+            "assembly",
+            "make"
+        ],
+        "cat": "Operating Systems",
+        "top": [
+            "virtualization",
+            " kernel",
+            "cloud",
+            " embedded systems",
+            "security"
+        ],
+        "year": [
+            2019,
+            2018,
+            2017,
+            2016,
+            2015,
+            2014,
+            2013,
+            2012,
+            2011
+        ],
+        "project": [
+            0,
+            0,
+            13,
+            11,
+            10,
+            14,
+            14,
+            12,
+            5,
+            8,
+            6,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5663378709676032/",
+        "name": "freifunk",
+        "tech": [
+            "c",
+            "python",
+            "ruby",
+            "openwrt",
+            "html/css/js",
+            "rust",
+            "c/c++",
+            "json",
+            "shell"
+        ],
+        "cat": "Social / Communications",
+        "top": [
+            "network",
+            "embedded systems",
+            "web apps",
+            "wireless communications",
+            "software defined networking",
+            "open hardware",
+            "wireless networks",
+            "decentralized",
+            "federation"
+        ],
+        "year": [
+            2021,
+            2019,
+            2018,
+            2012,
+            2011
+        ],
+        "project": [
+            0,
+            0,
+            9,
+            12,
+            0,
+            0,
+            0,
+            0,
+            0,
+            12,
+            10,
+            0,
+            7
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/4535509118877696/",
+        "name": "Genes, Genomes and Variation",
+        "tech": [
+            "perl",
+            "mysql",
+            "javascript",
+            "python",
+            "rest"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "genomics",
+            "data analysis",
+            "databases",
+            " scientific visualization"
+        ],
+        "year": [
+            2019,
+            2018,
+            2017,
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            5,
+            2,
+            3,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5661409025720320/",
+        "name": "GENIVI Alliance",
+        "tech": [
+            "yocto",
+            "embedded",
+            "automotive",
+            "some/ip"
+        ],
+        "cat": "Other",
+        "top": [
+            "automotive",
+            "graphics",
+            "communication",
+            "bigdata",
+            " embedded systems"
+        ],
+        "year": [
+            2019,
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            2,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/4808868352229376/",
+        "name": "GNU Compiler Collection",
+        "tech": [
+            "c/c++",
+            "gnu autotools"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "compilers",
+            "toolchain",
+            "openmp"
+        ],
+        "year": [
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            6,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5170270925488128/",
+        "name": "GNU Mailman",
+        "tech": [
+            "python 3",
+            "email",
+            "rest",
+            "django"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "email"
+        ],
+        "year": [
+            2019,
+            2016,
+            2015
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            3,
+            0,
+            0,
+            1,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/4979973948964864/",
+        "name": "gprMax",
+        "tech": [
+            "python",
+            "cuda",
+            "openmp",
+            "cython",
+            "mpi"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "engineering",
+            "geophysics",
+            "science",
+            "electromagnetics",
+            "ground penetrating radar",
+            "optimisation"
+        ],
+        "year": [
+            2021,
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            4
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6049761981890560/",
+        "name": "Haskell.Org",
+        "tech": [
+            "haskell",
+            "ghc",
+            "servant",
+            "codeworld",
+            "cabal"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "haskell",
+            "functional programming",
+            "education",
+            "build tools",
+            "compilers"
+        ],
+        "year": [
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            15,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/4934728610742272/",
+        "name": "Institut f\u00fcr Angewandte Informatik (InfAI) e.V.",
+        "tech": [
+            "java",
+            "javascript",
+            "a-frame",
+            "neo4j",
+            "htc vive"
+        ],
+        "cat": "Graphics / Video / Audio / Virtual Reality",
+        "top": [
+            "virtual reality",
+            "software quality",
+            "visualization",
+            "software analytics",
+            " web"
+        ],
+        "year": [
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6502123104108544/",
+        "name": "InterMine",
+        "tech": [
+            "java",
+            "python",
+            "javascript",
+            "clojure",
+            "r"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "bioinformatics",
+            " web",
+            " open science",
+            " biology",
+            " data visualisation"
+        ],
+        "year": [
+            2019,
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            6,
+            6,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6473524057735168/",
+        "name": "Internet Systems Consortium",
+        "tech": [
+            "c/c++",
+            "c99",
+            "mysql",
+            "python",
+            "javascript"
+        ],
+        "cat": "Other",
+        "top": [
+            "internet",
+            "networking",
+            "dhcp",
+            "dns",
+            "infrastructure"
+        ],
+        "year": [
+            2019,
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            1,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5195087733063680/",
+        "name": "JabRef",
+        "tech": [
+            "java",
+            "javafx",
+            "latex"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "academia",
+            "reference manager",
+            "bibtex",
+            "pdf"
+        ],
+        "year": [
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6743345328553984/",
+        "name": "Joomla",
+        "tech": [
+            "php",
+            "javascript",
+            "mysql",
+            "html/css",
+            "cms"
+        ],
+        "cat": "Web",
+        "top": [
+            "web",
+            "web development",
+            "web application",
+            "programming languages",
+            "cms"
+        ],
+        "year": [
+            2019,
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            8,
+            0,
+            3,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5987024522182656/",
+        "name": "JSK Robotics Laboratory / The University of Tokyo",
+        "tech": [
+            "ros",
+            "lisp"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "robotics",
+            "ros"
+        ],
+        "year": [
+            2019,
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6612711935311872/",
+        "name": "KNIME",
+        "tech": [
+            "javascript",
+            "java",
+            "tensorflow"
+        ],
+        "cat": "Data and Databases",
+        "top": [
+            "data analytics",
+            "data science",
+            "machine learning",
+            "deep learning",
+            "image processing"
+        ],
+        "year": [
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/4556574457069568/",
+        "name": "Libvirt",
+        "tech": [
+            "virtualization",
+            "kvm",
+            "xen",
+            "c",
+            "python"
+        ],
+        "cat": "Cloud",
+        "top": [
+            "virtualization",
+            "virtual machine",
+            "libraries",
+            "cloud"
+        ],
+        "year": [
+            2019,
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            4,
+            0,
+            0,
+            3,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5682474363912192/",
+        "name": "LLVM Compiler Infrastructure",
+        "tech": [
+            "llvm",
+            "clang"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "programming languages and development tools",
+            "compiler",
+            "code analysis"
+        ],
+        "year": [
+            2019,
+            2018,
+            2017,
+            2015,
+            2014,
+            2013,
+            2010,
+            2009
+        ],
+        "project": [
+            5,
+            5,
+            0,
+            0,
+            4,
+            4,
+            3,
+            0,
+            8,
+            8,
+            8,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5012931375267840/",
+        "name": "LuaRocks",
+        "tech": [
+            "lua"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "programming languages",
+            "package managers",
+            "games"
+        ],
+        "year": [
+            2019,
+            2018,
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            2,
+            2,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/4920269205929984/",
+        "name": "Matrix.org",
+        "tech": [
+            "python",
+            "javascript",
+            "nodejs",
+            "postgresql",
+            "go",
+            "decentralisation",
+            "rust",
+            "c++"
+        ],
+        "cat": "Social / Communications",
+        "top": [
+            "decentralisation",
+            "realtime communications",
+            "federated",
+            "interoperability",
+            "decentralized",
+            "json"
+        ],
+        "year": [
+            2021,
+            2019,
+            2018,
+            2017,
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            3,
+            2,
+            4,
+            0,
+            7
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6496732601384960/",
+        "name": "MBDyn - Multibody Dynamics",
+        "tech": [
+            "python",
+            "c++",
+            "scripting"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "mechanical engineering",
+            "aeronautics",
+            "multibody dynamics",
+            "aerodynamics",
+            "linear algebra"
+        ],
+        "year": [
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/4875887060713472/",
+        "name": "MetaBrainz Foundation Inc",
+        "tech": [
+            "python",
+            "perl",
+            "javascript",
+            "postgres",
+            "react",
+            "postgresql",
+            "spark",
+            "rust"
+        ],
+        "cat": "Data and Databases",
+        "top": [
+            "music",
+            "books",
+            "open data",
+            "metadata",
+            "community",
+            "databases",
+            "hosting"
+        ],
+        "year": [
+            2021,
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            6,
+            0,
+            5
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5681434444955648/",
+        "name": "Moodle",
+        "tech": [
+            "php",
+            "javascript",
+            "sql",
+            "angular",
+            "ionic"
+        ],
+        "cat": "Social / Communications",
+        "top": [
+            " education",
+            " web applications",
+            "e-learning",
+            "school system",
+            "learning management"
+        ],
+        "year": [
+            2019,
+            2018,
+            2017,
+            2016,
+            2015,
+            2014,
+            2013,
+            2012,
+            2011,
+            2009
+        ],
+        "project": [
+            5,
+            0,
+            3,
+            4,
+            6,
+            2,
+            2,
+            4,
+            1,
+            0,
+            2,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5873958367264768/",
+        "name": "Named Data Networking Project",
+        "tech": [
+            "java",
+            "android",
+            "javascript",
+            "c++14",
+            "c#"
+        ],
+        "cat": "Web",
+        "top": [
+            "networking",
+            "informationc centric networking",
+            "ipfs"
+        ],
+        "year": [
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6409236987248640/",
+        "name": "Netfilter project",
+        "tech": [
+            "c",
+            "linux kernel"
+        ],
+        "cat": "Operating Systems",
+        "top": [
+            "network security",
+            "software defined networking",
+            "network monitoring"
+        ],
+        "year": [
+            2019,
+            2018,
+            2017,
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            2,
+            3,
+            3,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5152196847468544/",
+        "name": "Open Astronomy",
+        "tech": [
+            "python",
+            "julia",
+            "c++",
+            "numba"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "visualisation",
+            "astronomy",
+            "solar physics",
+            "high energy astrophysics",
+            "orbital mechanics"
+        ],
+        "year": [
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            9,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6326136019091456/",
+        "name": "Open Bioinformatics Foundation",
+        "tech": [
+            "python",
+            "perl",
+            "java",
+            "javascript",
+            "biojs",
+            "c++",
+            "c",
+            "react"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "computational biology",
+            "bioinformatics",
+            "genomics",
+            "workflows"
+        ],
+        "year": [
+            2021,
+            2019,
+            2018,
+            2017,
+            2016,
+            2014,
+            2012,
+            2011,
+            2010
+        ],
+        "project": [
+            0,
+            5,
+            6,
+            5,
+            0,
+            6,
+            0,
+            7,
+            7,
+            5,
+            5,
+            0,
+            8
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5559834475233280/",
+        "name": "Open Data Kit",
+        "tech": [
+            "android",
+            "java"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "mobile",
+            " global development",
+            " global health",
+            " social good"
+        ],
+        "year": [
+            2019,
+            2018,
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            2,
+            2,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6491213031538688/",
+        "name": "Open Technologies Aliance - GFOSS",
+        "tech": [
+            "python",
+            "javascript",
+            "gtk",
+            "qt",
+            "arduino"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "robotics",
+            "programming languages",
+            "open education",
+            "c- c+",
+            "java"
+        ],
+        "year": [
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            13,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5738046581899264/",
+        "name": "Pharo Consortium",
+        "tech": [
+            "pharo",
+            "squeak",
+            "smalltalk",
+            "ide",
+            "os",
+            "roassal",
+            "spec"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "web development",
+            "data science",
+            "nlp",
+            "material design",
+            "cli",
+            "programming languages",
+            "virtual machines",
+            "compilers",
+            "ide",
+            "visualization"
+        ],
+        "year": [
+            2021,
+            2019,
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            5,
+            0,
+            7,
+            0,
+            6
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5607768440963072/",
+        "name": "phpMyAdmin",
+        "tech": [
+            "php",
+            "mysql",
+            "bootstrap",
+            "javascript",
+            "cakephp"
+        ],
+        "cat": "Data and Databases",
+        "top": [
+            "mysql",
+            "developer",
+            "administrator",
+            "database",
+            "web applications"
+        ],
+        "year": [
+            2019,
+            2018,
+            2017,
+            2015,
+            2014,
+            2013,
+            2012,
+            2011,
+            2010
+        ],
+        "project": [
+            0,
+            6,
+            7,
+            5,
+            6,
+            6,
+            4,
+            0,
+            3,
+            4,
+            2,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5716618817044480/",
+        "name": "Project PANOPTES",
+        "tech": [
+            "python 3",
+            "arduino",
+            "cloud"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "astronomy",
+            "robotics",
+            "exoplanet",
+            "image processing"
+        ],
+        "year": [
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6245542903939072/",
+        "name": "Public Lab",
+        "tech": [
+            "ruby on rails",
+            "javascript",
+            "node.js",
+            "raspberry pi",
+            "node"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "science",
+            "environment",
+            "collaboration",
+            "community",
+            "hardware",
+            "diversity",
+            "diy"
+        ],
+        "year": [
+            2021,
+            2019,
+            2018,
+            2017,
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            5,
+            5,
+            9,
+            12,
+            0,
+            4
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5218980686462976/",
+        "name": "R project for statistical computing",
+        "tech": [
+            "r-project",
+            "c",
+            "c++",
+            "fortran",
+            "javascript"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "data science",
+            "visualization",
+            "statistics",
+            "graphics",
+            "machine learning"
+        ],
+        "year": [
+            2019,
+            2018,
+            2017,
+            2016,
+            2012
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            16,
+            0,
+            0,
+            0,
+            22,
+            33,
+            24,
+            30,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5033715393101824/",
+        "name": "Read the Docs",
+        "tech": [
+            "python",
+            "django",
+            "documentation",
+            "sphinx"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "documentation",
+            "web"
+        ],
+        "year": [
+            2019,
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            2,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6207728010133504/",
+        "name": "Ruby Science Foundation",
+        "tech": [
+            "ruby",
+            "c/c++",
+            "cuda",
+            "ai",
+            "machine learning"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "scientific computing",
+            " scientific visualization",
+            "data-science",
+            "hpc",
+            "linear algebra"
+        ],
+        "year": [
+            2019,
+            2018,
+            2017,
+            2016,
+            2015,
+            2013
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            4,
+            0,
+            5,
+            4,
+            3,
+            4,
+            2,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5996747724161024/",
+        "name": "Salesforce",
+        "tech": [
+            "scala",
+            "apache spark",
+            "javascript",
+            "nodejs",
+            "react"
+        ],
+        "cat": "Cloud",
+        "top": [
+            "machine learning",
+            "natural language processing",
+            " web applications",
+            "user interface",
+            "cli"
+        ],
+        "year": [
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/4922378566500352/",
+        "name": "SCoRe Lab (Sustainable Computing Research Lab)",
+        "tech": [
+            "python",
+            "nodejs",
+            "android",
+            "golang"
+        ],
+        "cat": "Security",
+        "top": [
+            "information security",
+            "mobile",
+            "cloud",
+            "web development",
+            "machine learning"
+        ],
+        "year": [
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            27,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5700571963588608/",
+        "name": "shogun.ml",
+        "tech": [
+            "c++11",
+            "c++17",
+            "python",
+            "swig",
+            "cmake"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "machine learning",
+            "scientific computing",
+            "software engineering",
+            "user experience",
+            "data science"
+        ],
+        "year": [
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5660544999096320/",
+        "name": "Software and Computational Systems Lab at LMU Munich",
+        "tech": [
+            "python",
+            "java",
+            "javascript"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "software analysis",
+            "benchmarking",
+            "result presentation",
+            "smt solver",
+            "software verification"
+        ],
+        "year": [
+            2019,
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            2,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5396997154013184/",
+        "name": "Software Heritage",
+        "tech": [
+            "python",
+            "javascript",
+            "postgres",
+            "django",
+            "git",
+            "postgresql",
+            "elasticsearch"
+        ],
+        "cat": "Data and Databases",
+        "top": [
+            "digital preservation",
+            "source code archive",
+            "free and open source software",
+            "big data",
+            "big code",
+            "source code management",
+            "floss"
+        ],
+        "year": [
+            2021,
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            0,
+            2
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6051311592669184/",
+        "name": "SPDX (Software Product Data Exchange)",
+        "tech": [
+            "python",
+            "java",
+            "golang",
+            "xml"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "open source",
+            "compliance",
+            "licensing"
+        ],
+        "year": [
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            8,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6614261546090496/",
+        "name": "The Center for Connected Learning and Computer-Based Modeling",
+        "tech": [
+            "javascript",
+            "scala"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            " education",
+            "simulation",
+            "research",
+            "programming languages"
+        ],
+        "year": [
+            2019,
+            2018,
+            2017,
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            1,
+            2,
+            1,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/4793126693109760/",
+        "name": "The Eclipse Foundation",
+        "tech": [
+            "java",
+            "jakarta",
+            "javascript",
+            "openj9"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "ide",
+            "cloud",
+            "iot"
+        ],
+        "year": [
+            2019,
+            2018,
+            2017,
+            2015,
+            2014,
+            2013,
+            2012,
+            2011
+        ],
+        "project": [
+            0,
+            0,
+            16,
+            11,
+            11,
+            16,
+            15,
+            0,
+            10,
+            7,
+            10,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6559697677582336/",
+        "name": "The Perl Foundation",
+        "tech": [
+            "c",
+            "perl",
+            "regular expressions",
+            "perl6",
+            "perl5"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "web services",
+            "natural language understanding",
+            "functional programming",
+            "concurrency",
+            "programming languages and development tools"
+        ],
+        "year": [
+            2019,
+            2014,
+            2011,
+            2010,
+            2009
+        ],
+        "project": [
+            8,
+            8,
+            6,
+            0,
+            0,
+            5,
+            0,
+            0,
+            0,
+            0,
+            4,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6187982082539520/",
+        "name": "The Postgres Operator",
+        "tech": [
+            "postgresql",
+            "kubernetes",
+            "golang",
+            "operator",
+            "patroni"
+        ],
+        "cat": "Data and Databases",
+        "top": [
+            "cloud",
+            "cloud native",
+            "databases",
+            "database services",
+            "cloud databases"
+        ],
+        "year": [
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5422734538964992/",
+        "name": "The Processing Foundation",
+        "tech": [
+            "java",
+            "javascript",
+            "python",
+            "android",
+            "opengl"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "creative coding",
+            " graphics",
+            " web",
+            " education",
+            " design"
+        ],
+        "year": [
+            2019,
+            2018,
+            2017,
+            2015,
+            2014
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            11,
+            14,
+            0,
+            14,
+            16,
+            16,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5953843416793088/",
+        "name": "The Vega Project at the University of Washington",
+        "tech": [
+            "typescript",
+            "d3",
+            "vega",
+            "vega-lite",
+            "react"
+        ],
+        "cat": "Web",
+        "top": [
+            "visualization",
+            "data-science"
+        ],
+        "year": [
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6213357017759744/",
+        "name": "TimVideos.us",
+        "tech": [
+            "python",
+            "verilog",
+            "vhdl",
+            "c",
+            "fpga"
+        ],
+        "cat": "Graphics / Video / Audio / Virtual Reality",
+        "top": [
+            "hardware",
+            " embedded",
+            "video",
+            "fpga"
+        ],
+        "year": [
+            2019,
+            2018,
+            2016,
+            2014,
+            2013
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            2,
+            7,
+            0,
+            2,
+            0,
+            2,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6043030627287040/",
+        "name": "Tokio",
+        "tech": [
+            "tokio_rs",
+            "rust"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "rust",
+            "networking",
+            "windows",
+            "concurrency"
+        ],
+        "year": [
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5098459072299008/",
+        "name": "Tungsten Fabric",
+        "tech": [
+            "linux",
+            "kubernetes",
+            "python",
+            "networking",
+            "c/c++"
+        ],
+        "cat": "Cloud",
+        "top": [
+            "software defined networking",
+            "routing",
+            "security",
+            "multicloud"
+        ],
+        "year": [
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/4731456398557184/",
+        "name": "UCSC Xena",
+        "tech": [
+            "javascript",
+            "python",
+            "clojure",
+            "react"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "genomics",
+            "cancer research",
+            " scientific visualization",
+            "bioinformatics"
+        ],
+        "year": [
+            2019,
+            2018,
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            1,
+            1,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/4795917817872384/",
+        "name": "Xi Editor",
+        "tech": [
+            "rust",
+            "swift"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "ide",
+            "end user application",
+            "text editor"
+        ],
+        "year": [
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5008573141090304/",
+        "name": "XMPP Standards Foundation (XSF)",
+        "tech": [
+            "asynchronous i/o",
+            "lua",
+            "xmpp",
+            "java",
+            "python 3"
+        ],
+        "cat": "Social / Communications",
+        "top": [
+            "instant messaging",
+            "realtime communications",
+            "machine-to-machine",
+            "internet of things",
+            "xmpp"
+        ],
+        "year": [
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6320987639906304/",
+        "name": "xpra",
+        "tech": [
+            "python",
+            "javascript",
+            "c"
+        ],
+        "cat": "Graphics / Video / Audio / Virtual Reality",
+        "top": [
+            "remote-access",
+            "video",
+            "desktop",
+            "seamless"
+        ],
+        "year": [
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/4652389204754432/",
+        "name": "Zulip Open Source Project",
+        "tech": [
+            "python",
+            "react native",
+            "django",
+            "javascript",
+            "electron"
+        ],
+        "cat": "Social / Communications",
+        "top": [
+            "bots",
+            "mobile",
+            "visual design",
+            "chat",
+            "great developer tooling"
+        ],
+        "year": [
+            2019,
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            0,
+            0,
+            17,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5486812028469248/",
+        "name": "ZynAddSubFX",
+        "tech": [
+            "c/c++",
+            "ruby",
+            "midi",
+            "open-sound-control",
+            "opengl"
+        ],
+        "cat": "Graphics / Video / Audio / Virtual Reality",
+        "top": [
+            "audio",
+            "digital signal processing",
+            " visualization",
+            "music",
+            "user experience"
+        ],
+        "year": [
+            2019
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5685665089978368/",
+        "name": "3DTK",
+        "tech": [
+            "c/c++",
+            "cmake",
+            "opencv",
+            "ros",
+            "boost"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            " 3d",
+            "point clouds",
+            "slam",
+            "robotics",
+            "mapping"
+        ],
+        "year": [
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5067792839606272/",
+        "name": "52\u00b0 North Initiative for Geospatial Open Source Software GmbH",
+        "tech": [
+            "javascript",
+            "java",
+            "spring",
+            "r",
+            "big data"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "geoinformatics",
+            "geoprocessing",
+            "remote sensing",
+            "geostatistics",
+            "sensor web"
+        ],
+        "year": [
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5175246747336704/",
+        "name": "Apache Software Foundation",
+        "tech": [
+            "c",
+            "java",
+            "erlang"
+        ],
+        "cat": "Other",
+        "top": [
+            "other",
+            "cloud",
+            "libraries",
+            "big data"
+        ],
+        "year": [
+            2018,
+            2017,
+            2016,
+            2015,
+            2014,
+            2013,
+            2012,
+            2011,
+            2010
+        ],
+        "project": [
+            0,
+            39,
+            35,
+            38,
+            44,
+            33,
+            47,
+            35,
+            23,
+            23,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5706275094528000/",
+        "name": "Apertus Association",
+        "tech": [
+            "fpga",
+            "embedded",
+            "linux",
+            "c/c++",
+            "vhdl"
+        ],
+        "cat": "Graphics / Video / Audio / Virtual Reality",
+        "top": [
+            "vision",
+            "camera",
+            "cinematography",
+            "digital imaging",
+            "photography"
+        ],
+        "year": [
+            2018,
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            4,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5067823478472704/",
+        "name": "BeagleBoard.org Foundation",
+        "tech": [
+            "linux",
+            "gcc",
+            "real-time",
+            "physical computing",
+            "iot",
+            "risc-v",
+            "arm",
+            "dsp",
+            "fpga"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "robotics",
+            "ros",
+            "audio",
+            "iot",
+            "interfaces",
+            "ai",
+            "open hardware",
+            "process automation"
+        ],
+        "year": [
+            2021,
+            2018,
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            6,
+            3,
+            0,
+            0,
+            6
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5082029850886144/",
+        "name": "Beam Community",
+        "tech": [
+            "erlang",
+            "xmpp"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "distributed computing",
+            "real time",
+            "distributed databases",
+            "iot",
+            "instant messaging"
+        ],
+        "year": [
+            2018,
+            2017,
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            6,
+            7,
+            6,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5679790782676992/",
+        "name": "BeeWare Project",
+        "tech": [
+            "python",
+            "ios",
+            "android",
+            "javascript",
+            "java"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "mobile",
+            "cross desktop",
+            "app development"
+        ],
+        "year": [
+            2018,
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            2,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5751016104394752/",
+        "name": "Berkman Klein Center for Internet & Society at Harvard University",
+        "tech": [
+            "ruby on rails",
+            "meteor.js",
+            "elasticsearch",
+            "javascript",
+            "elk"
+        ],
+        "cat": "Other",
+        "top": [
+            " web",
+            " research",
+            "education",
+            "internet freedom",
+            "internet censorship"
+        ],
+        "year": [
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5123901926932480/",
+        "name": "Boost C++ Libraries",
+        "tech": [
+            "c++11",
+            "c++14",
+            "c++",
+            "c++17",
+            "c++20"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "c++ development",
+            "c++ tools",
+            "c++ standardization",
+            "software engineering",
+            "c++",
+            "algorithms",
+            "data structures",
+            "image processing"
+        ],
+        "year": [
+            2021,
+            2018,
+            2017,
+            2015,
+            2014,
+            2013,
+            2011,
+            2010
+        ],
+        "project": [
+            0,
+            9,
+            9,
+            0,
+            7,
+            8,
+            7,
+            0,
+            4,
+            9,
+            0,
+            0,
+            8
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5193342920949760/",
+        "name": "Boston University / XIA",
+        "tech": [
+            "xia",
+            "linux kernel",
+            "c",
+            "advanced data structures",
+            "ddos"
+        ],
+        "cat": "Cloud",
+        "top": [
+            "computer networking",
+            "future internet architecture",
+            "research"
+        ],
+        "year": [
+            2018,
+            2017,
+            2016,
+            2015
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            2,
+            2,
+            4,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/6272574585569280/",
+        "name": "Center for Research In Open Source Software (CROSS) at UC Santa Cruz",
+        "tech": [
+            "ceph",
+            "hadoop",
+            "c++",
+            "javascript",
+            "python"
+        ],
+        "cat": "Other",
+        "top": [
+            "distributed networks",
+            "reproducibility",
+            "storage systems",
+            "big data",
+            "opendata"
+        ],
+        "year": [
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5116840829255680/",
+        "name": "CHAOSS: Community Health Analytics Open Source Software",
+        "tech": [
+            "python 3",
+            "javascript"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "data visualization",
+            "visualization",
+            "machine learning"
+        ],
+        "year": [
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5667013157978112/",
+        "name": "CiviCRM LLC",
+        "tech": [
+            "php",
+            "mysql",
+            "angularjs",
+            "d3.js",
+            "angular"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "civil society",
+            "contacts&calendar sync",
+            "crm",
+            "nonprofit"
+        ],
+        "year": [
+            2021,
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            4,
+            0,
+            0,
+            4
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5114353707646976/",
+        "name": "Classical Language Toolkit",
+        "tech": [
+            "python",
+            "javascript"
+        ],
+        "cat": "Other",
+        "top": [
+            "natural language processing",
+            " web"
+        ],
+        "year": [
+            2018,
+            2017,
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            2,
+            3,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/6032491081105408/",
+        "name": "Conversations.im",
+        "tech": [
+            "java",
+            "android",
+            "xmpp",
+            "gtk",
+            "javascript"
+        ],
+        "cat": "Social / Communications",
+        "top": [
+            "instant messaging",
+            "mobile",
+            "desktop",
+            "web"
+        ],
+        "year": [
+            2018,
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            3,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/4794601982394368/",
+        "name": "Cuneiform Digital Library Initiative",
+        "tech": [
+            "python",
+            "mariadb",
+            "rdf",
+            "php",
+            "nltk"
+        ],
+        "cat": "Data and Databases",
+        "top": [
+            "natural language processing",
+            "machine translation",
+            "information retrieval",
+            "linguistics",
+            "semantic web"
+        ],
+        "year": [
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/6481377977434112/",
+        "name": "Debian Project",
+        "tech": [
+            "javascript",
+            "ruby",
+            "java",
+            "python",
+            "c/c++"
+        ],
+        "cat": "Operating Systems",
+        "top": [
+            "operating system",
+            "packaging",
+            "applications",
+            "community",
+            "communications"
+        ],
+        "year": [
+            2018,
+            2016,
+            2015,
+            2014,
+            2013,
+            2011,
+            2010
+        ],
+        "project": [
+            0,
+            8,
+            7,
+            0,
+            15,
+            17,
+            15,
+            20,
+            0,
+            22,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/4862665201549312/",
+        "name": "Earth Science Information Partners (ESIP)",
+        "tech": [
+            "kubernetes",
+            "dask",
+            "xarray",
+            "python",
+            "javascript"
+        ],
+        "cat": "Data and Databases",
+        "top": [
+            "earth data",
+            "semantics",
+            "discovery",
+            "data visualization",
+            "earth science"
+        ],
+        "year": [
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/4825444746526720/",
+        "name": "Eta",
+        "tech": [
+            "haskell",
+            "jvm",
+            "java"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "functional-programming",
+            "runtime systems",
+            "compilers",
+            "programming-tools"
+        ],
+        "year": [
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/6511795204259840/",
+        "name": "Free UK Genealogy",
+        "tech": [
+            "mongodb",
+            "ruby on rails",
+            "mysql",
+            "python",
+            "css/html"
+        ],
+        "cat": "Data and Databases",
+        "top": [
+            "ai",
+            "machine learning",
+            " ui/ux",
+            " web apps",
+            "open data"
+        ],
+        "year": [
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5472477677355008/",
+        "name": "GFOSS - Open Technologies Alliance",
+        "tech": [
+            "python 3",
+            "php/javascript/html",
+            "css/html",
+            "java",
+            "c/c++"
+        ],
+        "cat": "Other",
+        "top": [
+            "python",
+            "gtk",
+            "java jsp",
+            "c++ tools",
+            "javascript"
+        ],
+        "year": [
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            10,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/6595441034526720/",
+        "name": "GNU Project",
+        "tech": [
+            "c",
+            "lisp",
+            "python"
+        ],
+        "cat": "Operating Systems",
+        "top": [
+            "free software",
+            "operating system"
+        ],
+        "year": [
+            2018,
+            2016,
+            2015,
+            2014,
+            2013,
+            2012,
+            2009
+        ],
+        "project": [
+            7,
+            0,
+            0,
+            21,
+            30,
+            17,
+            12,
+            15,
+            0,
+            9,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/4768790235578368/",
+        "name": "gRPC",
+        "tech": [
+            "grpc",
+            "microservices",
+            "distributed systems",
+            "cloud"
+        ],
+        "cat": "Cloud",
+        "top": [
+            "microservices",
+            "communications",
+            "distributed networks",
+            "infrastructure",
+            "middleware"
+        ],
+        "year": [
+            2018,
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            1,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/6603344982310912/",
+        "name": "Inria Foundation",
+        "tech": [
+            "c/c++",
+            "qt",
+            "webassembly",
+            "asm",
+            "communication protocol"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "medical simulation",
+            "medical research",
+            "physics",
+            "real-time",
+            "scientific computing"
+        ],
+        "year": [
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/4682207855640576/",
+        "name": "Institute for Artificial Intelligence",
+        "tech": [
+            "c++",
+            "python",
+            "ros",
+            "unreal engine",
+            "lisp"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "artificial intelligence",
+            "robotics",
+            "simulation",
+            "unreal engine",
+            "perception"
+        ],
+        "year": [
+            2018,
+            2017,
+            2015,
+            2014
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            2,
+            0,
+            5,
+            6,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5956298361274368/",
+        "name": "JGraphT",
+        "tech": [
+            "java"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "graphs",
+            "algorithms",
+            "data structures",
+            "mathematics",
+            "network analysis"
+        ],
+        "year": [
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/6348667246084096/",
+        "name": "Jitsi",
+        "tech": [
+            "java",
+            "javascript",
+            "webrtc",
+            "react",
+            "react native"
+        ],
+        "cat": "Social / Communications",
+        "top": [
+            "real time communications",
+            "web",
+            "video conferencing",
+            "networking",
+            "multimedia"
+        ],
+        "year": [
+            2018,
+            2017,
+            2014
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            0,
+            0,
+            3,
+            3,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6265631002853376/",
+        "name": "Joomla!",
+        "tech": [
+            "php",
+            "javascript",
+            "mysql",
+            "html5/css3",
+            "cms",
+            "html",
+            "css"
+        ],
+        "cat": "Web",
+        "top": [
+            "web",
+            "web development",
+            "web applications",
+            "cms",
+            "object-oriented",
+            "programming languages"
+        ],
+        "year": [
+            2021,
+            2018,
+            2016,
+            2012,
+            2009
+        ],
+        "project": [
+            16,
+            0,
+            0,
+            7,
+            0,
+            0,
+            0,
+            5,
+            0,
+            7,
+            0,
+            0,
+            5
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/4898832450060288/",
+        "name": "languagetool.org",
+        "tech": [
+            "java",
+            "javascript",
+            "machine learning",
+            "ai",
+            "tensorflow"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "artificial intelligence",
+            "language",
+            "edtech",
+            "education",
+            "nlp"
+        ],
+        "year": [
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/6409962536304640/",
+        "name": "LEAP Encryption Access Project",
+        "tech": [
+            "python",
+            "twisted",
+            "javascript",
+            "openvpn",
+            "gnupg"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "e2e",
+            "mail",
+            "vpn",
+            "encryption"
+        ],
+        "year": [
+            2018,
+            2014
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5431834603159552/",
+        "name": "Mixxx DJ Software",
+        "tech": [
+            "qt",
+            "audio",
+            "music",
+            "real-time",
+            "c++"
+        ],
+        "cat": "Graphics / Video / Audio / Virtual Reality",
+        "top": [
+            "beatdetection",
+            "metadata"
+        ],
+        "year": [
+            2018,
+            2017,
+            2016,
+            2014,
+            2013,
+            2012
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            4,
+            4,
+            2,
+            0,
+            2,
+            2,
+            2,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/6557734510002176/",
+        "name": "Mobile Robot Programming Toolkit (MRPT)",
+        "tech": [
+            "c/c++",
+            "cmake",
+            "python",
+            "webs"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "robot",
+            "ai",
+            "computer vision",
+            "real-time",
+            "slam"
+        ],
+        "year": [
+            2018,
+            2017,
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            4,
+            1,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/4941292362530816/",
+        "name": "MovingBlocks",
+        "tech": [
+            "java",
+            "opengl",
+            "json",
+            "blender",
+            "github"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "game",
+            "voxel",
+            "minecraft",
+            "sandbox",
+            "modding"
+        ],
+        "year": [
+            2018,
+            2017,
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            10,
+            9,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/6067192269373440/",
+        "name": "omegaUp.com",
+        "tech": [
+            "php",
+            "mysql",
+            "python"
+        ],
+        "cat": "Web",
+        "top": [
+            "cs education",
+            "education",
+            "web community"
+        ],
+        "year": [
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5395828684357632/",
+        "name": "Open Food Facts",
+        "tech": [
+            "perl",
+            "mongodb",
+            "ios",
+            "android",
+            "machine learning"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "computer vision",
+            "crowdsourcing",
+            "open data",
+            "food",
+            "health"
+        ],
+        "year": [
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5792235979276288/",
+        "name": "Open Roberta Lab",
+        "tech": [
+            "java",
+            "javascript"
+        ],
+        "cat": "Web",
+        "top": [
+            "education",
+            "programming",
+            "robotics"
+        ],
+        "year": [
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/4806851430449152/",
+        "name": "Open States",
+        "tech": [
+            "python",
+            "django",
+            "react",
+            "graphql",
+            "postgresql"
+        ],
+        "cat": "Other",
+        "top": [
+            "civic tech",
+            "scraping",
+            "web",
+            "government"
+        ],
+        "year": [
+            2018,
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5351751314046976/",
+        "name": "OpenCensus",
+        "tech": [
+            "python",
+            "java",
+            "ruby",
+            "node",
+            "go"
+        ],
+        "cat": "Cloud",
+        "top": [
+            "tracing",
+            "monitoring",
+            "c++",
+            "php"
+        ],
+        "year": [
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/4660316541550592/",
+        "name": "OpenSIPS",
+        "tech": [
+            "c",
+            "python",
+            "mysql",
+            "scripting"
+        ],
+        "cat": "Social / Communications",
+        "top": [
+            "voip",
+            "telephony",
+            "real-time-communications",
+            "sip"
+        ],
+        "year": [
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5250379281334272/",
+        "name": "openSUSE",
+        "tech": [
+            "ruby on rail",
+            "perl",
+            "ruby",
+            "html/javascript",
+            "c/c++"
+        ],
+        "cat": "Operating Systems",
+        "top": [
+            " web",
+            "qa",
+            "packaging",
+            " ui/ux"
+        ],
+        "year": [
+            2018,
+            2017,
+            2016,
+            2014,
+            2013,
+            2012
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            9,
+            10,
+            14,
+            0,
+            6,
+            5,
+            2,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5214740582236160/",
+        "name": "OpnTec",
+        "tech": [
+            "python",
+            "javascript",
+            "emberjs",
+            "cloud",
+            "android"
+        ],
+        "cat": "Social / Communications",
+        "top": [
+            "open event",
+            "event solutions",
+            "web"
+        ],
+        "year": [
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/6376279188176896/",
+        "name": "OW2",
+        "tech": [
+            "java",
+            "perl",
+            "middleware",
+            "bpm",
+            "wiki"
+        ],
+        "cat": "Other",
+        "top": [
+            "enterprise information systems",
+            "cloud",
+            "security",
+            "middleware"
+        ],
+        "year": [
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/4692141242580992/",
+        "name": "P2PSP.org",
+        "tech": [
+            "python",
+            "javascript",
+            "webrtc",
+            "sockets",
+            "c/c++"
+        ],
+        "cat": "Graphics / Video / Audio / Virtual Reality",
+        "top": [
+            "live streaming",
+            "real time",
+            "distributed networks",
+            "p2p",
+            "video"
+        ],
+        "year": [
+            2018,
+            2017,
+            2016,
+            2015
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            2,
+            2,
+            1,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5208530327961600/",
+        "name": "phpBB Forum Software",
+        "tech": [
+            "mysql",
+            "javascript",
+            "html5/css3",
+            "php",
+            "symfony"
+        ],
+        "cat": "Social / Communications",
+        "top": [
+            "social",
+            "communication",
+            "collaboration",
+            "forum",
+            "community"
+        ],
+        "year": [
+            2018,
+            2017,
+            2014,
+            2013,
+            2012
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            3,
+            5,
+            3,
+            0,
+            0,
+            2,
+            2,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5782644243562496/",
+        "name": "Plone",
+        "tech": [
+            "python",
+            "javascript",
+            "html",
+            "css",
+            "reactjs"
+        ],
+        "cat": "Web",
+        "top": [
+            "communications",
+            "collaboration",
+            "content management",
+            "web"
+        ],
+        "year": [
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            4,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5852375185096704/",
+        "name": "PMD",
+        "tech": [
+            "java",
+            "xml",
+            "javacc",
+            "antlr",
+            "xpath"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "code analysis",
+            "code quality",
+            "source code analyzer",
+            "linter"
+        ],
+        "year": [
+            2018,
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            1,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/6441884142534656/",
+        "name": "Pocket Science Lab",
+        "tech": [
+            "android",
+            "java",
+            "firmware",
+            "c",
+            "cad"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "science",
+            "education",
+            "firmware",
+            "school apps"
+        ],
+        "year": [
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/4933265605525504/",
+        "name": "Polly Labs",
+        "tech": [
+            "c/c++",
+            "llvm",
+            "polly",
+            "isl",
+            "ppcg"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "compilers",
+            "polyhedral model"
+        ],
+        "year": [
+            2018,
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            3,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5818041149423616/",
+        "name": "Probot",
+        "tech": [
+            "javascript",
+            "node",
+            "github"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "bot",
+            "automation",
+            "development tools"
+        ],
+        "year": [
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5331740188999680/",
+        "name": "Python HYDRA",
+        "tech": [
+            "python",
+            "rdf",
+            "flask",
+            "hydra",
+            "json/json-ld"
+        ],
+        "cat": "Web",
+        "top": [
+            "apis",
+            "database",
+            "functional-programming",
+            "semantic web",
+            "knowledge graph"
+        ],
+        "year": [
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/4724462213660672/",
+        "name": "Quill.org",
+        "tech": [
+            "ruby",
+            "rails",
+            "react",
+            "javascript",
+            "postgresql"
+        ],
+        "cat": "Web",
+        "top": [
+            "education",
+            "edtech",
+            "machine learning",
+            "nlp",
+            "web"
+        ],
+        "year": [
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5393348407853056/",
+        "name": "radare",
+        "tech": [
+            "c",
+            "cpp",
+            "rust",
+            "qt"
+        ],
+        "cat": "Security",
+        "top": [
+            "reverse engineering"
+        ],
+        "year": [
+            2018,
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            0,
+            5,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5729327995944960/",
+        "name": "Rspamd",
+        "tech": [
+            "c",
+            "machine learning",
+            "javascript",
+            "lua"
+        ],
+        "cat": "Security",
+        "top": [
+            "email",
+            "spam filtering",
+            "high performance computing"
+        ],
+        "year": [
+            2018,
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5717023518621696/",
+        "name": "Ruby on Rails",
+        "tech": [
+            "ruby",
+            "ruby on rails",
+            "html"
+        ],
+        "cat": "Web",
+        "top": [
+            "web",
+            "web development",
+            "web applications"
+        ],
+        "year": [
+            2018,
+            2017,
+            2015,
+            2014,
+            2013,
+            2009
+        ],
+        "project": [
+            4,
+            0,
+            0,
+            0,
+            5,
+            7,
+            6,
+            0,
+            2,
+            2,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5677303661068288/",
+        "name": "Sage Mathematical Software System",
+        "tech": [
+            "python 3",
+            "python",
+            "cython",
+            "c/c++"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "mathematics",
+            "toolbox"
+        ],
+        "year": [
+            2018,
+            2017,
+            2016,
+            2015,
+            2014,
+            2013,
+            2012
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            3,
+            3,
+            5,
+            5,
+            5,
+            5,
+            5,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5122715136557056/",
+        "name": "Scala",
+        "tech": [
+            "scala",
+            "jvm",
+            "llvm"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "compilers",
+            "programming-tools",
+            "functional-programming",
+            "programming-language"
+        ],
+        "year": [
+            2018,
+            2017,
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            9,
+            8,
+            1,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/4786317862895616/",
+        "name": "Scilab",
+        "tech": [
+            "c",
+            "c++",
+            "java",
+            "scilab"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "science",
+            "mathematics",
+            "numerical computation",
+            "graphics"
+        ],
+        "year": [
+            2018,
+            2017,
+            2012,
+            2011
+        ],
+        "project": [
+            0,
+            0,
+            7,
+            10,
+            0,
+            0,
+            0,
+            0,
+            5,
+            4,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5132636779446272/",
+        "name": "Seastar",
+        "tech": [
+            "cpp",
+            "framework",
+            "dpdk",
+            "tcp",
+            "linux"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "high performance",
+            "tcp",
+            "app development",
+            "network",
+            "framework"
+        ],
+        "year": [
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5667370274127872/",
+        "name": "Space @ Virginia Tech",
+        "tech": [
+            "python",
+            "javascript",
+            "d3",
+            "mysql",
+            "mongodb"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "real time",
+            "web",
+            "data visualization",
+            "data analytics"
+        ],
+        "year": [
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/6199903000723456/",
+        "name": "Stemformatics",
+        "tech": [
+            "python",
+            "javascript",
+            "postgresql"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "web applications",
+            "cloud",
+            "bioinformatics"
+        ],
+        "year": [
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6522897060855808/",
+        "name": "STE||AR Group",
+        "tech": [
+            "c++",
+            "cuda",
+            "opencv",
+            "python",
+            "boost"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "hpc",
+            "parallel algorithms",
+            "runtime systems",
+            "distributed datastructures",
+            "asynchronous many task systems",
+            "parallelism",
+            "concurrency",
+            "high-performance computing",
+            "machine learning"
+        ],
+        "year": [
+            2021,
+            2018,
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            4,
+            4,
+            0,
+            0,
+            2
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/6275038890164224/",
+        "name": "Stony Brook University Biomedical Informatics",
+        "tech": [
+            "python",
+            "matlab",
+            "c++",
+            "javascript"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "biomedical data science",
+            "cancer informatics",
+            "deep learning",
+            "medical imaging"
+        ],
+        "year": [
+            2018,
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            4,
+            0,
+            2,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5918428024012800/",
+        "name": "Streetmix",
+        "tech": [
+            "javascript",
+            "react",
+            "redux",
+            "postgresql",
+            "mongodb"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "smart cities",
+            "web",
+            "civic tech"
+        ],
+        "year": [
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5745237494333440/",
+        "name": "Sustainable Computing Research Group (SCoRe)",
+        "tech": [
+            "android",
+            "java",
+            "go",
+            "node",
+            "pyth"
+        ],
+        "cat": "Web",
+        "top": [
+            "iot",
+            "web",
+            "mobile",
+            "machine learning",
+            "security"
+        ],
+        "year": [
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            18,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/6321870005600256/",
+        "name": "Systers Community",
+        "tech": [
+            "ios",
+            "android",
+            "python",
+            "ruby on rails",
+            "javascript"
+        ],
+        "cat": "Other",
+        "top": [
+            "mobile applications",
+            " web apps",
+            "community"
+        ],
+        "year": [
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            11,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/6265117784145920/",
+        "name": "TEAMMATES @ National University of Singapore",
+        "tech": [
+            "java",
+            "appengine",
+            "javascript"
+        ],
+        "cat": "Web",
+        "top": [
+            "education",
+            "teaching",
+            "cloud",
+            "web applications"
+        ],
+        "year": [
+            2018,
+            2017,
+            2016,
+            2015
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            6,
+            7,
+            8,
+            5,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/4867664006610944/",
+        "name": "The MacPorts Project",
+        "tech": [
+            "tcl",
+            "html/javascript",
+            "frontend",
+            "vue.js",
+            "react.js"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "package manager",
+            "mac os x",
+            "macos",
+            "command line",
+            "build tools"
+        ],
+        "year": [
+            2018,
+            2017,
+            2015,
+            2014,
+            2011,
+            2010,
+            2009
+        ],
+        "project": [
+            2,
+            3,
+            3,
+            0,
+            0,
+            3,
+            2,
+            0,
+            2,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/6475167723159552/",
+        "name": "The Qt Project",
+        "tech": [
+            "c++11",
+            "cpp",
+            "qt",
+            "qml",
+            "opengl"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "graphics",
+            "gis",
+            "maps",
+            "declarative language"
+        ],
+        "year": [
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5651276360581120/",
+        "name": "The syslog-ng project.",
+        "tech": [
+            "java",
+            "c/c++",
+            "big data",
+            "elasticsearch",
+            "rest"
+        ],
+        "cat": "Security",
+        "top": [
+            "logging",
+            "log management",
+            "message queue",
+            "python"
+        ],
+        "year": [
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/4645580374540288/",
+        "name": "The Vega Visualization Tools by the UW Interactive Data Lab",
+        "tech": [
+            "javascript",
+            "typescript",
+            "react",
+            "d3.js"
+        ],
+        "cat": "Data and Databases",
+        "top": [
+            "data visualization",
+            "visualization grammar",
+            "data science",
+            "declarative language",
+            "plotting tools"
+        ],
+        "year": [
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/6308187447754752/",
+        "name": "TLA+",
+        "tech": [
+            "java",
+            "tla+",
+            "eclipse",
+            "ocaml",
+            "smt"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "formal methods",
+            "algorithms"
+        ],
+        "year": [
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5088548537499648/",
+        "name": "ViSP",
+        "tech": [
+            "c/c++"
+        ],
+        "cat": "Graphics / Video / Audio / Virtual Reality",
+        "top": [
+            "robotics",
+            "computer vision"
+        ],
+        "year": [
+            2018,
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            2,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5714570659758080/",
+        "name": "vitrivr",
+        "tech": [
+            "java",
+            "angularjs",
+            "spark",
+            "grpc",
+            "kotlin",
+            "typescript",
+            "angular",
+            "tensorflow"
+        ],
+        "cat": "Data and Databases",
+        "top": [
+            "retrieval",
+            "multimedia",
+            "video",
+            "audio",
+            "3d",
+            "multimedia retrieval",
+            "machine learning",
+            "computer vision",
+            "databases",
+            "web"
+        ],
+        "year": [
+            2021,
+            2018,
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            0,
+            1,
+            0,
+            0,
+            2
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/4651790628814848/",
+        "name": "WorldBrain.io - Verifying the Internet",
+        "tech": [
+            "react",
+            "javascript",
+            "browser extension",
+            "datproject"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "search",
+            "fake-news",
+            "decentralization",
+            "misinformation",
+            "bookmarking"
+        ],
+        "year": [
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/4893771770626048/",
+        "name": "X.org Foundation",
+        "tech": [
+            "opengl",
+            "vulkan",
+            "x11",
+            "wayland",
+            "opencl"
+        ],
+        "cat": "Graphics / Video / Audio / Virtual Reality",
+        "top": [
+            "graphic stack",
+            "3d acceleration",
+            "2d acceleration",
+            "media acceleration",
+            "windowing system"
+        ],
+        "year": [
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5991099608858624/",
+        "name": "XBMC Foundation",
+        "tech": [
+            "python",
+            "c/c++",
+            "github",
+            "mysql"
+        ],
+        "cat": "Graphics / Video / Audio / Virtual Reality",
+        "top": [
+            "home theater",
+            "audio",
+            "video"
+        ],
+        "year": [
+            2018,
+            2017,
+            2015,
+            2012
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            4,
+            0,
+            0,
+            3,
+            0,
+            3,
+            2,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/6530090020110336/",
+        "name": "Xi Editor Project",
+        "tech": [
+            "rust",
+            "swift"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "text editing",
+            "ide"
+        ],
+        "year": [
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5969765231230976/",
+        "name": "xpra.org",
+        "tech": [
+            "python",
+            "javascript",
+            "compression",
+            "remote access",
+            "cython"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "graphics",
+            "remote access"
+        ],
+        "year": [
+            2018
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5677990456852480/",
+        "name": "AboutCode",
+        "tech": [
+            "python",
+            "c/c++",
+            "javascript",
+            "shell script",
+            "static analysis",
+            "django",
+            "postgres"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "free and open source software  license and origin",
+            "package and dependencies licensing and origin",
+            "package vulnerabilities and security",
+            "code scan and matching",
+            "code analysis and spdx",
+            "software composition analysis",
+            "software packages",
+            "scanning"
+        ],
+        "year": [
+            2021,
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            4,
+            0,
+            0,
+            0,
+            4
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/5933754749026304/",
+        "name": "Babel",
+        "tech": [
+            "javascript",
+            "babel",
+            "nodejs"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "compilers",
+            "ast",
+            "minifier",
+            "tc39"
+        ],
+        "year": [
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/5825274612547584/",
+        "name": "Berkman Klein Center for Internet and Society at Harvard University",
+        "tech": [
+            "ruby on rails",
+            "meteor.js",
+            "d3",
+            "elasticsearch",
+            "javascript"
+        ],
+        "cat": "Web",
+        "top": [
+            "digital rights",
+            "internet access",
+            "security and privacy",
+            "law",
+            " web"
+        ],
+        "year": [
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            5,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/6571413242642432/",
+        "name": "Cadasta",
+        "tech": [
+            "python",
+            "django",
+            "javasc",
+            "javascipt"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "web",
+            "land rights",
+            "mapping",
+            "geo",
+            "geospatial"
+        ],
+        "year": [
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/6259684285087744/",
+        "name": "Ceph",
+        "tech": [
+            "c++",
+            "python",
+            "object-storage",
+            "angular",
+            "javascript",
+            "typescript"
+        ],
+        "cat": "Data and Databases",
+        "top": [
+            "cloud storage",
+            "storage",
+            "distributed systems"
+        ],
+        "year": [
+            2021,
+            2017,
+            2016,
+            2014
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            4,
+            4,
+            0,
+            0,
+            0,
+            7
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/5054104644616192/",
+        "name": "Clojure",
+        "tech": [
+            "clojure",
+            "clojurescript",
+            "jvm",
+            "javascript",
+            "functional programming"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "programming language",
+            "development tools",
+            "compilers",
+            "functional programming",
+            "build systems"
+        ],
+        "year": [
+            2017,
+            2015,
+            2014,
+            2013
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            6,
+            9,
+            5,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/5510422639673344/",
+        "name": "CMU Sphinx",
+        "tech": [
+            "c",
+            "cross-platform",
+            "hidden markov models",
+            "javascript",
+            "python"
+        ],
+        "cat": "Graphics / Video / Audio / Virtual Reality",
+        "top": [
+            "speech recognition",
+            "user interface",
+            "real time",
+            "education",
+            "pronunciation"
+        ],
+        "year": [
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            11,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/6180004551458816/",
+        "name": "Copyleft Games",
+        "tech": [
+            "python",
+            "opengl",
+            "javascript",
+            "c",
+            "xmpp"
+        ],
+        "cat": "Graphics / Video / Audio / Virtual Reality",
+        "top": [
+            "graphics",
+            "networking",
+            "web",
+            "education"
+        ],
+        "year": [
+            2017,
+            2016,
+            2015,
+            2014
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            5,
+            8,
+            2,
+            2,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/4878856288731136/",
+        "name": "Discourse",
+        "tech": [
+            "ruby on rails",
+            "ember",
+            "ruby",
+            "javascipt",
+            "html/css"
+        ],
+        "cat": "Social / Communications",
+        "top": [
+            "asynchronous",
+            "forum",
+            "community",
+            " real time",
+            "web development"
+        ],
+        "year": [
+            2017,
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            4,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/5851994006749184/",
+        "name": "Eclipse Vert.x",
+        "tech": [
+            "java",
+            "reactive extensions",
+            "kotlin",
+            "microservices",
+            "event-loop"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "reactive",
+            "unopionated",
+            "polyglot",
+            "distributed",
+            "high performance computing"
+        ],
+        "year": [
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/5658990390280192/",
+        "name": "Elm Software Foundation",
+        "tech": [
+            "elm",
+            "javascript",
+            "haskell"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "functional programming",
+            "compilers",
+            "web applications",
+            "programming languages",
+            "user interface"
+        ],
+        "year": [
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/4941941976334336/",
+        "name": "Environmental Data And Governance Initiative",
+        "tech": [
+            "python",
+            "javascript",
+            "ruby on rails",
+            "google cloud",
+            "go"
+        ],
+        "cat": "Data and Databases",
+        "top": [
+            "crawling",
+            "api",
+            "open data",
+            "machine learning",
+            "open science"
+        ],
+        "year": [
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/6004756195573760/",
+        "name": "Freifunk",
+        "tech": [
+            "lede/openwrt",
+            "c",
+            "html/css",
+            "shell script",
+            "javascript"
+        ],
+        "cat": "Social / Communications",
+        "top": [
+            "wireless",
+            "routing",
+            "monitoring",
+            "firmware development",
+            "user interface"
+        ],
+        "year": [
+            2017,
+            2016,
+            2014,
+            2010,
+            2009
+        ],
+        "project": [
+            10,
+            8,
+            0,
+            0,
+            0,
+            8,
+            0,
+            8,
+            12,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/4597892144693248/",
+        "name": "Frescobaldi",
+        "tech": [
+            "python",
+            "pyqt"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "music engraving"
+        ],
+        "year": [
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/4914104280023040/",
+        "name": "GENIVI Development Platform",
+        "tech": [
+            "linux",
+            "c",
+            "yocto",
+            "c++",
+            "qt"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "automotive",
+            "cars",
+            "embedded systems",
+            "embedded",
+            "automobile"
+        ],
+        "year": [
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/6147412729004032/",
+        "name": "Green Navigation",
+        "tech": [
+            "javascript",
+            "java",
+            "react",
+            "apache spark",
+            "tensorflow"
+        ],
+        "cat": "Other",
+        "top": [
+            "routing",
+            "eletric mobility",
+            "web",
+            "machine learning"
+        ],
+        "year": [
+            2017,
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            5,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/6221940343701504/",
+        "name": "illumos.org",
+        "tech": [
+            "dtrace",
+            "illumos",
+            "unix",
+            "openzfs",
+            "zfs"
+        ],
+        "cat": "Operating Systems",
+        "top": [
+            "drivers",
+            "virtualization",
+            "storage",
+            "networking",
+            "kernel"
+        ],
+        "year": [
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/6149200777576448/",
+        "name": "Intel Media and Audio for Linux",
+        "tech": [
+            "video",
+            "decode",
+            "encode",
+            "vpp",
+            "multimedia"
+        ],
+        "cat": "Graphics / Video / Audio / Virtual Reality",
+        "top": [
+            "accelerated media",
+            "video",
+            "compress",
+            "encoding",
+            "camera"
+        ],
+        "year": [
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/6380010977886208/",
+        "name": "JSK Robotics Laboratory",
+        "tech": [
+            "ros",
+            "lisp",
+            "prolog",
+            "openhrp",
+            "openrtm"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "robotics",
+            "artificial intelligence"
+        ],
+        "year": [
+            2017,
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/6184001823834112/",
+        "name": "K-9 Mail",
+        "tech": [
+            "android",
+            "java"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "email",
+            "communication"
+        ],
+        "year": [
+            2017,
+            2011
+        ],
+        "project": [
+            0,
+            0,
+            4,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/5586250824155136/",
+        "name": "KDE",
+        "tech": [
+            "c++",
+            "qt",
+            "qt5"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "desktop",
+            "desktop application",
+            "education",
+            "science",
+            "communication"
+        ],
+        "year": [
+            2017,
+            2016,
+            2015,
+            2014,
+            2013,
+            2012,
+            2011,
+            2010,
+            2009
+        ],
+        "project": [
+            37,
+            46,
+            47,
+            59,
+            50,
+            39,
+            36,
+            32,
+            24,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/5279287632461824/",
+        "name": "Liquid Galaxy Project",
+        "tech": [
+            "javascript",
+            "ros",
+            "gis",
+            "cesiumjs"
+        ],
+        "cat": "Graphics / Video / Audio / Virtual Reality",
+        "top": [
+            "virtual reality",
+            "geospatial",
+            "visualisation",
+            "graphics",
+            "webvr"
+        ],
+        "year": [
+            2017,
+            2016,
+            2015,
+            2014,
+            2013,
+            2012,
+            2011
+        ],
+        "project": [
+            0,
+            0,
+            3,
+            3,
+            3,
+            5,
+            6,
+            4,
+            3,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/4752192066027520/",
+        "name": "MariaDB",
+        "tech": [
+            "mariadb",
+            "mysql",
+            "c",
+            "c++",
+            "java"
+        ],
+        "cat": "Data and Databases",
+        "top": [
+            "database"
+        ],
+        "year": [
+            2017,
+            2016,
+            2015,
+            2014,
+            2013
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            3,
+            4,
+            3,
+            5,
+            1,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/5026327212064768/",
+        "name": "Microkernel devroom",
+        "tech": [
+            "c",
+            "c++",
+            "rust",
+            "arm",
+            "x86"
+        ],
+        "cat": "Operating Systems",
+        "top": [
+            "microkernel",
+            "components",
+            "ipc",
+            "desktop",
+            "virtualization"
+        ],
+        "year": [
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/5486404108812288/",
+        "name": "Mifos Initiative",
+        "tech": [
+            "java",
+            "android",
+            "angularjs",
+            "spring",
+            "mysql"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "fintech",
+            "mobile banking",
+            "digital financial services",
+            "microfinance",
+            "financial inclusion"
+        ],
+        "year": [
+            2017,
+            2016,
+            2014
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            7,
+            0,
+            6,
+            10,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/4814565460148224/",
+        "name": "Mono Project",
+        "tech": [
+            "c#",
+            ".net",
+            "f#",
+            "c"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "compiler",
+            "ide",
+            "mobile development",
+            "web development",
+            "programming tools"
+        ],
+        "year": [
+            2017,
+            2015,
+            2014,
+            2013,
+            2012,
+            2011,
+            2009
+        ],
+        "project": [
+            6,
+            0,
+            13,
+            12,
+            14,
+            12,
+            13,
+            0,
+            9,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/5603880054292480/",
+        "name": "Nmap Security Scanner",
+        "tech": [
+            "c/c++",
+            "lua",
+            "python",
+            "c",
+            "c++"
+        ],
+        "cat": "Security",
+        "top": [
+            "security",
+            "networking",
+            "ipv6",
+            "linux",
+            "network mapping"
+        ],
+        "year": [
+            2017,
+            2016,
+            2015,
+            2014,
+            2013,
+            2012,
+            2011,
+            2010,
+            2009
+        ],
+        "project": [
+            6,
+            8,
+            7,
+            4,
+            3,
+            4,
+            5,
+            5,
+            4,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/6015282623545344/",
+        "name": "Open Detection",
+        "tech": [
+            "c++",
+            "caffe",
+            "pcl",
+            "opencv"
+        ],
+        "cat": "Other",
+        "top": [
+            "computer vision",
+            "ai"
+        ],
+        "year": [
+            2017,
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            2,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/6266968780832768/",
+        "name": "Open Technologies Alliance - GFOSS",
+        "tech": [
+            "php",
+            "java",
+            "mysql",
+            "virtuoso",
+            "python"
+        ],
+        "cat": "Other",
+        "top": [
+            "data",
+            "cloud",
+            "hardware"
+        ],
+        "year": [
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            4,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/5718999941775360/",
+        "name": "oVirt",
+        "tech": [
+            "java",
+            "python",
+            "kvm"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "virtualization",
+            "enterprise application"
+        ],
+        "year": [
+            2017,
+            2014
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            0,
+            2,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/5721528872206336/",
+        "name": "ownCloud",
+        "tech": [
+            "php",
+            "qt",
+            "android",
+            "ios",
+            "javascript"
+        ],
+        "cat": "Cloud",
+        "top": [
+            "cloud",
+            "sync",
+            "file share"
+        ],
+        "year": [
+            2017,
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            3,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/6491731667189760/",
+        "name": "Physical Web Project",
+        "tech": [
+            "beacon",
+            "web bluetooth",
+            "physical web",
+            "bluetooth"
+        ],
+        "cat": "Other",
+        "top": [
+            "internet of things",
+            "beacons"
+        ],
+        "year": [
+            2017,
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            5,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/4530756705583104/",
+        "name": "Plone Foundation",
+        "tech": [
+            "python",
+            "javascript",
+            "html/css"
+        ],
+        "cat": "Web",
+        "top": [
+            " content management",
+            "cms"
+        ],
+        "year": [
+            2017,
+            2016,
+            2014,
+            2013,
+            2011,
+            2010,
+            2009
+        ],
+        "project": [
+            5,
+            4,
+            3,
+            0,
+            2,
+            2,
+            0,
+            3,
+            4,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/5827042528460800/",
+        "name": "Portland State University",
+        "tech": [
+            "open hardware",
+            "language-agnostic"
+        ],
+        "cat": "Other",
+        "top": [
+            "new projects",
+            "academic projects",
+            "individual projects"
+        ],
+        "year": [
+            2017,
+            2016,
+            2015,
+            2014,
+            2013,
+            2012,
+            2011,
+            2010,
+            2009
+        ],
+        "project": [
+            6,
+            5,
+            11,
+            8,
+            8,
+            11,
+            11,
+            6,
+            7,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/4795019735072768/",
+        "name": "radare2",
+        "tech": [
+            "c",
+            "rust",
+            "python",
+            "nodejs"
+        ],
+        "cat": "Security",
+        "top": [
+            "reverse engineering"
+        ],
+        "year": [
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/4704476053110784/",
+        "name": "Shogun Machine Learning Toolbox",
+        "tech": [
+            "c/c++",
+            "python",
+            "swig",
+            "machine learning",
+            "cmake"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "machine learning",
+            " statistics",
+            " fast algorithms",
+            " bioinformatics",
+            " software engineering"
+        ],
+        "year": [
+            2017,
+            2016,
+            2014,
+            2013,
+            2012
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            8,
+            8,
+            8,
+            0,
+            3,
+            4,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/5019976297611264/",
+        "name": "Sigmah",
+        "tech": [
+            "gwt",
+            "java",
+            "postgresql"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "humanitarian",
+            "project-management"
+        ],
+        "year": [
+            2017,
+            2016,
+            2014,
+            2013,
+            2012
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            2,
+            3,
+            3,
+            0,
+            1,
+            2,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/6300304437936128/",
+        "name": "Software Product Data Exchange (SPDX)",
+        "tech": [
+            "rdf",
+            "python",
+            "java",
+            "github",
+            "c"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "compliance",
+            "opensource",
+            "licensing"
+        ],
+        "year": [
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            4,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/6367868836904960/",
+        "name": "Stony Brook University, Biomedical Informatics",
+        "tech": [
+            "big data",
+            "apache spark",
+            "matlab",
+            "c++",
+            "hadoop"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "biomedical informatics",
+            "medical imaging",
+            "bioinformtics",
+            "big data",
+            "database"
+        ],
+        "year": [
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/4984473024200704/",
+        "name": "Sustainable Computing Research Group ( SCoRe )",
+        "tech": [
+            "python",
+            "java",
+            "gcp",
+            "android",
+            "golan"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "iot",
+            "security",
+            "mobile applications",
+            "embedded systems"
+        ],
+        "year": [
+            2017,
+            2016,
+            2015
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            7,
+            16,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/5429781541683200/",
+        "name": "Systers, an Anita Borg Institute community",
+        "tech": [
+            "android",
+            "ios",
+            "python",
+            "java",
+            "javascript"
+        ],
+        "cat": "Other",
+        "top": [
+            "women in tech",
+            "games",
+            "peace corps",
+            "web",
+            "mobile"
+        ],
+        "year": [
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            11,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/6565611412914176/",
+        "name": "The CGAL Project",
+        "tech": [
+            "c++",
+            "git",
+            "github"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "computational geometry",
+            "geometry processing",
+            "mesh processing",
+            "triangulaton",
+            "arrangement"
+        ],
+        "year": [
+            2017,
+            2013
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            7,
+            0,
+            0,
+            0,
+            4,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/4699374705704960/",
+        "name": "The FreeType Project",
+        "tech": [
+            "fonts",
+            "opentype",
+            "c",
+            "library"
+        ],
+        "cat": "Graphics / Video / Audio / Virtual Reality",
+        "top": [
+            "fonts",
+            "opentype",
+            "rendering",
+            "graphics",
+            "truetype"
+        ],
+        "year": [
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/6470814639587328/",
+        "name": "Tiled",
+        "tech": [
+            "qt",
+            "c++",
+            "git",
+            "github"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "edit",
+            "editing",
+            "level",
+            "game",
+            "game development"
+        ],
+        "year": [
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/6543856732471296/",
+        "name": "TimVideos",
+        "tech": [
+            "python",
+            "verilog",
+            "fpga",
+            "vhdl",
+            "c"
+        ],
+        "cat": "Graphics / Video / Audio / Virtual Reality",
+        "top": [
+            "hardware",
+            "embedded",
+            "video",
+            "fpga"
+        ],
+        "year": [
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/5273949793419264/",
+        "name": "Tor",
+        "tech": [
+            "c",
+            "python",
+            "javascript",
+            "c++"
+        ],
+        "cat": "Security",
+        "top": [
+            "privacy",
+            " anonymity",
+            " counter-censorship",
+            "free-speech"
+        ],
+        "year": [
+            2017,
+            2013
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            6,
+            0,
+            0,
+            0,
+            4,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/4513544758362112/",
+        "name": "Urban Energy Systems Laboratory, Empa",
+        "tech": [
+            "python",
+            "gis",
+            "fast fluid dynamics"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "distributed energy systems",
+            "modeling & optimization",
+            "data portal"
+        ],
+        "year": [
+            2017,
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            3,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/6393325913374720/",
+        "name": "WorldBrain - Verifying the Internet with Science",
+        "tech": [
+            "reactjs",
+            "javascript"
+        ],
+        "cat": "Social / Communications",
+        "top": [
+            "fake-news",
+            "misinformation",
+            "search",
+            "digital knowledge"
+        ],
+        "year": [
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/6070843662663680/",
+        "name": "WSO2",
+        "tech": [
+            "soa",
+            "middleware",
+            "java",
+            "distributed computing",
+            "web services"
+        ],
+        "cat": "Other",
+        "top": [
+            "cloud",
+            "iot",
+            "security",
+            "micro services",
+            "api management"
+        ],
+        "year": [
+            2017,
+            2016,
+            2015,
+            2014
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            5,
+            9,
+            11,
+            9,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/5262324659126272/",
+        "name": "wxWidgets",
+        "tech": [
+            "c++",
+            "gtk+",
+            "win32",
+            "cocoa"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "cross-platform",
+            "desktop",
+            "gui"
+        ],
+        "year": [
+            2017,
+            2014,
+            2011,
+            2010,
+            2009
+        ],
+        "project": [
+            3,
+            5,
+            3,
+            0,
+            0,
+            6,
+            0,
+            0,
+            2,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/5748328394391552/",
+        "name": "Xen Project",
+        "tech": [
+            "linux",
+            "free/netbsd",
+            "asm/c/c++",
+            "qemu",
+            "ocaml"
+        ],
+        "cat": "Cloud",
+        "top": [
+            "virtualization",
+            "security",
+            "cloud computing",
+            "unikernels",
+            "embedded/automotive"
+        ],
+        "year": [
+            2017,
+            2014
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            5,
+            0,
+            0,
+            2,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2017/organizations/4744852235354112/",
+        "name": "Zenodo",
+        "tech": [
+            "python",
+            "postgresql",
+            "flask",
+            "angularjs",
+            "elasticsearch"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "content management",
+            "web",
+            "open science",
+            "digital library",
+            "machine learning"
+        ],
+        "year": [
+            2017
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/5127141637226496/",
+        "name": "AOSSIE - The Australian National University's Open-Source Software Innovation and Education",
+        "tech": [
+            "scala",
+            "lisp",
+            "llvm",
+            "python",
+            "postgresql"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "logic",
+            "live programming",
+            "data analysis",
+            "health",
+            "privacy"
+        ],
+        "year": [
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            6,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/6488526010974208/",
+        "name": "ArchC",
+        "tech": [
+            "c++",
+            "python",
+            "archc"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "computer architecture",
+            "processor design",
+            "simulators"
+        ],
+        "year": [
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/5175650340044800/",
+        "name": "ASCEND",
+        "tech": [
+            "python",
+            "c",
+            "c/c++"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "engineering",
+            "simulation",
+            "system modelling",
+            "mathematical software",
+            "solver"
+        ],
+        "year": [
+            2016,
+            2015,
+            2012,
+            2011,
+            2010,
+            2009
+        ],
+        "project": [
+            5,
+            4,
+            6,
+            6,
+            0,
+            0,
+            5,
+            3,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/6488734048452608/",
+        "name": "Berkman Center for Internet and Society",
+        "tech": [
+            "ruby on rails",
+            "javascript",
+            "sql/nosql",
+            "meteor.js",
+            "go"
+        ],
+        "cat": "",
+        "top": [
+            "censorship",
+            "education",
+            "internet freedom",
+            "digital rights",
+            "law and policy"
+        ],
+        "year": [
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            10,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/6650532982685696/",
+        "name": "BioJS",
+        "tech": [
+            "javascript",
+            "python"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "javascript",
+            "bioinformatics",
+            "life sciences",
+            "coding standards",
+            "visualization"
+        ],
+        "year": [
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/4929075730710528/",
+        "name": "BuildmLearn",
+        "tech": [
+            "python",
+            "django",
+            "bootstrap",
+            "android"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "mlearning",
+            "mobile app",
+            "web apps",
+            "education"
+        ],
+        "year": [
+            2016,
+            2015,
+            2014
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            6,
+            4,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/5630110493310976/",
+        "name": "Canadian Centre for Computational Genomics (C3G) - Montreal node",
+        "tech": [
+            "python",
+            "r-project",
+            "javascript",
+            "sql",
+            "git"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "bioinformatics",
+            "visualization",
+            "statistics",
+            "genomics",
+            "population genetics"
+        ],
+        "year": [
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/4955769220890624/",
+        "name": "Celluloid",
+        "tech": [
+            "ruby",
+            "multi-threading",
+            "multi-core",
+            "zeromq",
+            "high-resolution timers"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "concurrency",
+            "parallel",
+            "evented",
+            "distributed",
+            "actor model"
+        ],
+        "year": [
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/6273708926697472/",
+        "name": "CERN SFT",
+        "tech": [
+            "c++",
+            "python",
+            "javascript",
+            "clang"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "numerical and data analysis software",
+            "simulation software",
+            "cloud",
+            "machine learning"
+        ],
+        "year": [
+            2016,
+            2015,
+            2014,
+            2013,
+            2012
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            7,
+            8,
+            11,
+            14,
+            10,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/5902411419877376/",
+        "name": "Computational Science and Engineering at TU Wien",
+        "tech": [
+            "javascript",
+            "html",
+            "css",
+            "java",
+            "c++"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "science and enineering",
+            "internet of things",
+            "visualization",
+            "simulation",
+            "mesh generation"
+        ],
+        "year": [
+            2016,
+            2014,
+            2013,
+            2012,
+            2011
+        ],
+        "project": [
+            0,
+            0,
+            3,
+            9,
+            12,
+            14,
+            0,
+            10,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/6020075270176768/",
+        "name": "CVXPY",
+        "tech": [
+            "python"
+        ],
+        "cat": "",
+        "top": [
+            "convex optimization",
+            "optimization",
+            "dsl"
+        ],
+        "year": [
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/4688223091556352/",
+        "name": "D Foundation",
+        "tech": [
+            "dlang",
+            "c++"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "compilers"
+        ],
+        "year": [
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            4,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/6313893177589760/",
+        "name": "dbpediaspotlight",
+        "tech": [
+            "java",
+            "scala",
+            "rdf",
+            "python",
+            "nosql"
+        ],
+        "cat": "Data and Databases",
+        "top": [
+            "natural language processing",
+            "big data",
+            "semantic web",
+            "data science"
+        ],
+        "year": [
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            8,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/5457125316755456/",
+        "name": "Distributed and Unified Numerics Environment (DUNE)",
+        "tech": [
+            "c++",
+            "python",
+            "cmake"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "partial differential equations",
+            "physics",
+            "mathematics",
+            "high performance computing",
+            "scientific computing"
+        ],
+        "year": [
+            2016,
+            2013
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            0,
+            2,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/4603925500002304/",
+        "name": "FOSDEM VZW",
+        "tech": [
+            "ruby on rails",
+            "postgresql",
+            "git"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "web",
+            "programming tools",
+            "programming",
+            "programming languages",
+            "ruby"
+        ],
+        "year": [
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/6393779032424448/",
+        "name": "Gambit - Software Tools for Game Theory",
+        "tech": [
+            "javascript"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "game theory",
+            "academic projects",
+            "graphics"
+        ],
+        "year": [
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/5865050841546752/",
+        "name": "Ganeti",
+        "tech": [
+            "python",
+            "haskell",
+            "kvm",
+            "xen",
+            "virtualization"
+        ],
+        "cat": "",
+        "top": [
+            "virtualization",
+            "automation"
+        ],
+        "year": [
+            2016,
+            2015,
+            2014,
+            2013
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            2,
+            2,
+            1,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/5632763172487168/",
+        "name": "GitHub",
+        "tech": [
+            "git",
+            "atom",
+            "node.js",
+            "ruby",
+            "c#"
+        ],
+        "cat": "",
+        "top": [
+            "git",
+            "version control",
+            "editor",
+            "collaboration"
+        ],
+        "year": [
+            2016,
+            2015
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            5,
+            4,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/6536303764045824/",
+        "name": "Global Alliance for Genomics & Health",
+        "tech": [
+            "python",
+            "java",
+            "protobuf",
+            "sql"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "genomics",
+            "big data",
+            "standards",
+            "apis",
+            "data sharing"
+        ],
+        "year": [
+            2016,
+            2015
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            3,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/5800194151022592/",
+        "name": "gnss-sdr",
+        "tech": [
+            "c/c++",
+            "c++11",
+            "c++14",
+            "gnss"
+        ],
+        "cat": "Social / Communications",
+        "top": [
+            "communications",
+            "geolocation",
+            "navigation",
+            "software defined radio"
+        ],
+        "year": [
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/5849050746191872/",
+        "name": "Health Information Systems Programme",
+        "tech": [
+            "java",
+            "android",
+            "javascript",
+            "reactjs",
+            "gradle"
+        ],
+        "cat": "",
+        "top": [
+            "mobile",
+            "data processing",
+            "gis",
+            "e-health",
+            "global health and development"
+        ],
+        "year": [
+            2016,
+            2014,
+            2013
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            4,
+            5,
+            0,
+            6,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/5096012251136000/",
+        "name": "Indic Project",
+        "tech": [
+            "android",
+            "python",
+            "javascript",
+            "ruby on rails",
+            "c++"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "natural language processing",
+            "language techology",
+            "input methods"
+        ],
+        "year": [
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            7,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/6563422992859136/",
+        "name": "International Neuroinformatics Coordinating Facility",
+        "tech": [
+            "c++",
+            "python",
+            "gpu",
+            "javascript",
+            "java"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "neuroscience",
+            "data science",
+            "simulation",
+            "visualization",
+            "big data"
+        ],
+        "year": [
+            2016,
+            2015,
+            2014,
+            2013,
+            2012,
+            2011
+        ],
+        "project": [
+            0,
+            0,
+            2,
+            6,
+            6,
+            12,
+            12,
+            12,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/4723150839349248/",
+        "name": "Java Pathfinder Team",
+        "tech": [
+            "java",
+            "jvm",
+            "android",
+            "distributed systems"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "program analysis",
+            "testing",
+            "verification",
+            "model checking",
+            "environment generation"
+        ],
+        "year": [
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            10,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/4879888423059456/",
+        "name": "Jenkins Project",
+        "tech": [
+            "java",
+            "groovy",
+            "jenkins",
+            "css",
+            "html"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "automation",
+            "continuous integration",
+            "continuous delivery",
+            "java",
+            "development"
+        ],
+        "year": [
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/5754903989321728/",
+        "name": "jQuery Foundation",
+        "tech": [
+            "javascript",
+            "html5",
+            "css",
+            "jquery"
+        ],
+        "cat": "",
+        "top": [
+            "unit testing",
+            "software testing",
+            "framework development",
+            "user interface components",
+            "event handling"
+        ],
+        "year": [
+            2016,
+            2015
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            7,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/5678701068943360/",
+        "name": "KolibriOS",
+        "tech": [
+            "fasm",
+            "flat assembler",
+            "x86 assembly",
+            "i386",
+            "i586"
+        ],
+        "cat": "Operating Systems",
+        "top": [
+            "desktop",
+            "operating systems",
+            "drivers",
+            "hardware",
+            "lowlevel"
+        ],
+        "year": [
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            4,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/6241651022364672/",
+        "name": "MBDyn, Department of Aerospace Science and Technology at Politecnico di Milano",
+        "tech": [
+            "c++"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "physics",
+            "engineering",
+            "simulation",
+            "robotics",
+            "real time"
+        ],
+        "year": [
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/4739150934704128/",
+        "name": "McGill Space Institute",
+        "tech": [
+            "python",
+            "sql",
+            "databases",
+            "big data"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "space",
+            "astronomy"
+        ],
+        "year": [
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/4969202133762048/",
+        "name": "MetaBrainz Foundation",
+        "tech": [
+            "python",
+            "perl",
+            "postgresql",
+            "javascript"
+        ],
+        "cat": "Data and Databases",
+        "top": [
+            "music",
+            "metadata",
+            "machine learning",
+            "big data",
+            "books"
+        ],
+        "year": [
+            2016,
+            2009
+        ],
+        "project": [
+            2,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            4,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/5954860486754304/",
+        "name": "MIT Media Lab",
+        "tech": [
+            "java",
+            "html/javascript",
+            "android"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "educational technology",
+            "education"
+        ],
+        "year": [
+            2016,
+            2015
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            6,
+            5,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/5115751115522048/",
+        "name": "mlpack: a scalable C++ machine learning library",
+        "tech": [
+            "c++"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "machine learning",
+            "data mining",
+            "fast algorithms"
+        ],
+        "year": [
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            6,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/6377072951820288/",
+        "name": "ModSecurity",
+        "tech": [
+            "waf",
+            "web application firewall"
+        ],
+        "cat": "Security",
+        "top": [
+            "web application security"
+        ],
+        "year": [
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/5166380995313664/",
+        "name": "Open Ephys",
+        "tech": [
+            "c++",
+            "juce"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "neuroscience",
+            "electrophysiology",
+            "visualization",
+            "ui",
+            "signal processing"
+        ],
+        "year": [
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/5672889575538688/",
+        "name": "OpenKeychain (OpenPGP for Android)",
+        "tech": [
+            "android",
+            "openpgp"
+        ],
+        "cat": "Security",
+        "top": [
+            "security",
+            "e-mail",
+            "encryption"
+        ],
+        "year": [
+            2016,
+            2015,
+            2014
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            2,
+            2,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/6400146589876224/",
+        "name": "Orange \u2013 Data Mining Fruitful & Fun",
+        "tech": [
+            "python",
+            "cython",
+            "qt",
+            "machine learning"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "machine learning",
+            "visualization",
+            "data mining",
+            "bioinformatics",
+            "gui toolkit"
+        ],
+        "year": [
+            2016,
+            2012,
+            2011
+        ],
+        "project": [
+            0,
+            0,
+            3,
+            3,
+            0,
+            0,
+            0,
+            5,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/6434461499523072/",
+        "name": "OSGeo - The Open Source Geospatial Foundation",
+        "tech": [
+            "python",
+            "sql",
+            "c",
+            "ogc standards",
+            "c++"
+        ],
+        "cat": "",
+        "top": [
+            "gis",
+            "science",
+            "maps",
+            "cartography",
+            "geospatial"
+        ],
+        "year": [
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            20,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/4845666660515840/",
+        "name": "OSU Open Source Lab",
+        "tech": [
+            "python",
+            "rest",
+            "javascript",
+            "ruby"
+        ],
+        "cat": "",
+        "top": [
+            "virtualization",
+            "infrastructure"
+        ],
+        "year": [
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/5191954035900416/",
+        "name": "Peragro",
+        "tech": [
+            "python",
+            "blender",
+            "javascript",
+            "celery",
+            "django"
+        ],
+        "cat": "",
+        "top": [
+            "analyzing",
+            "transcoding",
+            "pipeline automation",
+            "games",
+            "web"
+        ],
+        "year": [
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/6066521583386624/",
+        "name": "PLASMA-UMass",
+        "tech": [
+            "javascript",
+            "c/c++",
+            "scala",
+            "go"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "programming languages",
+            "programming tools",
+            "software engineering",
+            "operating systems",
+            "runtime systems"
+        ],
+        "year": [
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/4609839401533440/",
+        "name": "PRISM Model Checker",
+        "tech": [
+            "java",
+            "c++"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "science",
+            "verification",
+            "probabilistic models"
+        ],
+        "year": [
+            2016,
+            2014,
+            2013
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            2,
+            8,
+            0,
+            5,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/6723762711953408/",
+        "name": "Robocomp",
+        "tech": [
+            "c++",
+            "python",
+            "zeroc ice",
+            "cmake",
+            "gnu/linux"
+        ],
+        "cat": "",
+        "top": [
+            "robotics",
+            "framework",
+            "computer vision"
+        ],
+        "year": [
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            5,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/5960176045654016/",
+        "name": "Scilab Enterprises",
+        "tech": [
+            "scilab",
+            "c++",
+            "java",
+            "c",
+            "fortran"
+        ],
+        "cat": "Science and Medicine",
+        "top": [
+            "engineering",
+            "mechanics",
+            "vision",
+            "graphics",
+            "user interface"
+        ],
+        "year": [
+            2016,
+            2015
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            4,
+            5,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/6477188102619136/",
+        "name": "Soletta Project",
+        "tech": [
+            "c",
+            "python",
+            "javascript",
+            "networking",
+            "machine learning"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "internet of things",
+            "portable",
+            "robotics",
+            "drones",
+            "makers"
+        ],
+        "year": [
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/5689792285114368/",
+        "name": "Systers, an Anita Borg Institute Community",
+        "tech": [
+            "python",
+            "android",
+            "ios",
+            "mysql",
+            "ruby on rails"
+        ],
+        "cat": "",
+        "top": [
+            "women in tech",
+            "systers",
+            "women in open source"
+        ],
+        "year": [
+            2016,
+            2015,
+            2014,
+            2013
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            6,
+            13,
+            22,
+            19,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/5377487227846656/",
+        "name": "The Apertium Project",
+        "tech": [
+            "c++",
+            "python",
+            "perl",
+            "xml",
+            "finite-state technologies"
+        ],
+        "cat": "Social / Communications",
+        "top": [
+            "machine translation",
+            "computer-aided translation",
+            "morphological analysis",
+            "natural language processing",
+            "human language technologies"
+        ],
+        "year": [
+            2016,
+            2009
+        ],
+        "project": [
+            8,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            11,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/5269666368847872/",
+        "name": "The Monarch Initiative",
+        "tech": [
+            "semantic web",
+            "javascript",
+            "text mining",
+            "named entity recognition",
+            "ontologies"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "embeddable widget",
+            "rare disease",
+            "data refinement"
+        ],
+        "year": [
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/6112304055713792/",
+        "name": "The STE||AR Group",
+        "tech": [
+            "parallel processing",
+            "high performance computing",
+            "c++",
+            "cuda",
+            "opencl"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "runtime systems",
+            "parallel computing",
+            "high performance computing",
+            "hpx",
+            "gpu"
+        ],
+        "year": [
+            2016,
+            2015,
+            2014
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            5,
+            4,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/4906518294036480/",
+        "name": "The syslog-ng project",
+        "tech": [
+            "c",
+            "java",
+            "python",
+            "big data",
+            "rust"
+        ],
+        "cat": "Security",
+        "top": [
+            "log management",
+            "message queue",
+            "data extraction",
+            "message correlation",
+            "continuous delivery"
+        ],
+        "year": [
+            2016,
+            2015,
+            2014
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            4,
+            4,
+            4,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/6183886396588032/",
+        "name": "The Tor Project",
+        "tech": [
+            "c",
+            "javascript",
+            "golang",
+            "python",
+            "browser extensions"
+        ],
+        "cat": "Security",
+        "top": [
+            "privacy",
+            "security",
+            "anonymity",
+            "anti-censorship",
+            "research"
+        ],
+        "year": [
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            5,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/6356852245790720/",
+        "name": "Timelab Technologies Ltd.",
+        "tech": [
+            "python",
+            "javascript"
+        ],
+        "cat": "End User Applications",
+        "top": [
+            "astronomy",
+            "algorithm prototyping/visualization",
+            "mathematics",
+            "time series"
+        ],
+        "year": [
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/6601174413213696/",
+        "name": "Unitex/GramLab",
+        "tech": [
+            "java",
+            "c++"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "natural language processing",
+            "local grammars",
+            "finite state automata",
+            "corpus annotation",
+            "multilingual language resources"
+        ],
+        "year": [
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/5126842331693056/",
+        "name": "Vert.x",
+        "tech": [
+            "java",
+            "reactive",
+            "javascript",
+            "groovy",
+            "micro-services"
+        ],
+        "cat": "Programming Languages and Development Tools",
+        "top": [
+            "micro services",
+            "high performance computing"
+        ],
+        "year": [
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/4704929172160512/",
+        "name": "VideoLAN / VLMC Project",
+        "tech": [
+            "opengl",
+            "c++",
+            "c",
+            "assembly",
+            "qt"
+        ],
+        "cat": "Graphics / Video / Audio / Virtual Reality",
+        "top": [
+            "video",
+            "multimedia",
+            "editor",
+            "editing",
+            "non-linear"
+        ],
+        "year": [
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "url": "https://summerofcode.withgoogle.com/archive/2016/organizations/4886349127614464/",
+        "name": "Wayland",
+        "tech": [
+            "opengl",
+            "wayland",
+            "c",
+            "xml",
+            "kms"
+        ],
+        "cat": "Graphics / Video / Audio / Virtual Reality",
+        "top": [
+            "graphics",
+            "window system",
+            "display",
+            "video"
+        ],
+        "year": [
+            2016
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0
+        ]
+    },
+    {
+        "name": "xrdesktop",
+        "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5134539654955008/",
+        "tech": [
+            "glib",
+            "openxr",
+            "vulkan",
+            "c",
+            "wayland"
+        ],
+        "cat": "Graphics / Video / Audio / Virtual Reality",
+        "top": [
+            "graphics",
+            "3dui",
+            "virtual reality",
+            "window management",
+            "real time"
+        ],
+        "year": [
+            2021
+        ],
+        "project": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            2
+        ]
+    }
 ]

--- a/src/data/finalData.json
+++ b/src/data/finalData.json
@@ -3,18 +3,35 @@
         "url": "https://summerofcode.withgoogle.com/archive/2021/organizations/5129526253715456/",
         "name": "52\u00b0 North GmbH",
         "tech": [
-            "java",
-            "android",
             "javascript",
-            "python",
-            "react",
+            "java",
             "ogc standards",
-            "web services"
+            "web services",
+            "web",
+            "spring",
+            "r",
+            "big data",
+            "android",
+            "python",
+            "react"
         ],
         "cat": "Science and Medicine",
         "top": [
-            "web services",
+            "spatial data",
+            "sensor web",
+            "web-based geoprocessing",
+            "earth observation",
+            "geoinformatics",
+            "spatial data infrastructures",
+            "spatial information",
+            "geoprocessing",
+            "remote sensing",
+            "geostatistics",
+            "ogc",
+            "web processing",
+            "sensorweb",
             "floating car data",
+            "web services",
             "ogc standards",
             "trajectory analytics",
             "spatial information infrastructures",
@@ -23,8 +40,12 @@
             "geoinformation systems"
         ],
         "year": [
-            2021,
-            2020
+            2016,
+            2017,
+            2018,
+            2019,
+            2020,
+            2021
         ],
         "project": [
             0,
@@ -34,10 +55,10 @@
             0,
             0,
             0,
-            0,
-            0,
-            0,
-            0,
+            3,
+            1,
+            1,
+            2,
             3,
             3
         ]
@@ -10209,8 +10230,10 @@
         "year": [
             2021,
             2020,
+            2019,
             2018,
-            2017
+            2017,
+            2016
         ],
         "project": [
             0,
@@ -10220,54 +10243,12 @@
             0,
             0,
             0,
-            0,
+            3,
             10,
             10,
-            0,
+            17,
             18,
             18
-        ]
-    },
-    {
-        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/6331236958601216/",
-        "name": "52\u00b0North Initiative for Geospatial Open Source Software GmbH",
-        "tech": [
-            "javascript",
-            "android",
-            "web",
-            "java"
-        ],
-        "cat": "Science and Medicine",
-        "top": [
-            "ogc",
-            "web processing",
-            "sensorweb",
-            "floating car data",
-            "earth observation"
-        ],
-        "year": [
-            2019,
-            2017,
-            2016,
-            2015,
-            2014,
-            2013,
-            2012
-        ],
-        "project": [
-            0,
-            0,
-            0,
-            4,
-            4,
-            4,
-            6,
-            3,
-            1,
-            0,
-            2,
-            0,
-            0
         ]
     },
     {
@@ -13302,44 +13283,6 @@
         ]
     },
     {
-        "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/4652389204754432/",
-        "name": "Zulip Open Source Project",
-        "tech": [
-            "python",
-            "react native",
-            "django",
-            "javascript",
-            "electron"
-        ],
-        "cat": "Social / Communications",
-        "top": [
-            "bots",
-            "mobile",
-            "visual design",
-            "chat",
-            "great developer tooling"
-        ],
-        "year": [
-            2019,
-            2016
-        ],
-        "project": [
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            3,
-            0,
-            0,
-            17,
-            0,
-            0
-        ]
-    },
-    {
         "url": "https://summerofcode.withgoogle.com/archive/2019/organizations/5486812028469248/",
         "name": "ZynAddSubFX",
         "tech": [
@@ -13408,43 +13351,6 @@
             0,
             0,
             2,
-            0,
-            0,
-            0
-        ]
-    },
-    {
-        "url": "https://summerofcode.withgoogle.com/archive/2018/organizations/5067792839606272/",
-        "name": "52\u00b0 North Initiative for Geospatial Open Source Software GmbH",
-        "tech": [
-            "javascript",
-            "java",
-            "spring",
-            "r",
-            "big data"
-        ],
-        "cat": "Science and Medicine",
-        "top": [
-            "geoinformatics",
-            "geoprocessing",
-            "remote sensing",
-            "geostatistics",
-            "sensor web"
-        ],
-        "year": [
-            2018
-        ],
-        "project": [
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            1,
             0,
             0,
             0


### PR DESCRIPTION
Add 2021 data of organizations, as compiled from [here](https://api.gsocorganizations.dev/2021.json).
Update tech, topics, and number of projects.
Also fix 2 organizations' old data.